### PR TITLE
✨Add clipboard command to copy file fullpath (cpcb)

### DIFF
--- a/src/main/bash/functions_clipboard.sh
+++ b/src/main/bash/functions_clipboard.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: functions_clipboard.sh
+# DESCRIPTION: Clipboard operations for copying file paths
+########################################################################################################################
+
+########################################################################################################################
+# FUNCTION: _i_get_clipboard_tool
+# DESCRIPTION: Detect and return the available clipboard tool
+# RETURN: Echoes the clipboard command to use (xclip, xsel, pbcopy, or empty)
+########################################################################################################################
+function _i_get_clipboard_tool() {
+  if command -v xclip &> /dev/null; then
+    echo "xclip -selection clipboard"
+  elif command -v xsel &> /dev/null; then
+    echo "xsel --clipboard --input"
+  elif command -v pbcopy &> /dev/null; then
+    echo "pbcopy"
+  else
+    echo ""
+  fi
+}
+
+########################################################################################################################
+# FUNCTION: _copy_fullpath_to_clipboard
+# DESCRIPTION: Copy the full path of a file or directory to the clipboard
+# PARAMETERS:
+#   $1 - File or directory name (optional, defaults to current directory)
+# USAGE: cpcb [filename]
+# EXAMPLE:
+#   cpcb                    # Copies current directory full path
+#   cpcb myfile.txt         # Copies full path of myfile.txt
+#   cpcb ../some/path       # Copies full path of relative path
+########################################################################################################################
+function _copy_fullpath_to_clipboard() {
+  local target="${1:-.}"
+  local fullpath
+  local clipboard_tool
+
+  # Check if clipboard tool is available
+  clipboard_tool=$(_i_get_clipboard_tool)
+  if [[ -z "$clipboard_tool" ]]; then
+    _i_log_as_error "No clipboard tool found. Please install xclip, xsel, or pbcopy."
+    return 1
+  fi
+
+  # Check if the target exists
+  if [[ ! -e "$target" ]]; then
+    _i_log_as_error "File or directory '$target' does not exist."
+    return 1
+  fi
+
+  # Get the absolute path
+  fullpath=$(realpath "$target" 2>/dev/null)
+  if [[ $? -ne 0 ]]; then
+    # Fallback if realpath is not available
+    fullpath=$(cd "$(dirname "$target")" && pwd)/$(basename "$target")
+  fi
+
+  # Copy to clipboard
+  echo -n "$fullpath" | eval "$clipboard_tool"
+  if [[ $? -eq 0 ]]; then
+    _i_log_as_info "Copied to clipboard: $fullpath"
+    _i_log_ok
+  else
+    _i_log_as_error "Failed to copy to clipboard."
+    return 1
+  fi
+}

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -196,6 +196,7 @@ function _i_load_bindings() {
 alias c=_mark_folder_as_current
 alias cdf=_change_directory_from_filepath
 alias cf=_mark_file_as_current
+alias cpcb=_copy_fullpath_to_clipboard
 alias ik=_interactive_kill
 alias sucd=_su_to_current_directory
 alias sn=_snapshot_file

--- a/src/main/help/help_files_folders
+++ b/src/main/help/help_files_folders
@@ -15,6 +15,9 @@ c : mark current folder, use "gc" to go this folder from any place
 Marking
 cf FILEPATH : mark file as current, use "gcf" to open it in vim from any place
 ------------------------------------------------------------------------------------------------------------------------
+Clipboard
+cpcb [FILEPATH] : copy full path of file to clipboard (defaults to current directory if no argument)
+------------------------------------------------------------------------------------------------------------------------
 Safe delete
 [CTRL + X then E] display a safe rm command such as `rm -i -rf /tmp/qmt/anyfolder && cd..` to quickly delete current folder and to avoid `rm -rf *` in your bash history.
 [CTRL + X then R] display a safe rm command such as `rm -i -rf /tmp/qmt/anyfolder/* ` to quickly delete current folder contents and to avoid `rm -rf *` in your bash history.


### PR DESCRIPTION
Add new cpcb command that copies the full path of a file or directory to the clipboard.
- Created functions_clipboard.sh with clipboard detection (xclip/xsel/pbcopy)
- Added cpcb alias in nixlper.sh
- Updated help documentation with usage examples
- Supports relative paths, defaults to current directory if no argument provided