### PR TITLE
✨Add cpdcb command to copy directory path to clipboard

### DIFF
--- a/src/main/bash/functions_clipboard.sh
+++ b/src/main/bash/functions_clipboard.sh
@@ -67,3 +67,64 @@ function _copy_fullpath_to_clipboard() {
     return 1
   fi
 }
+
+########################################################################################################################
+# FUNCTION: _copy_directory_to_clipboard
+# DESCRIPTION: Copy the full path of the directory containing a file to the clipboard
+# PARAMETERS:
+#   $1 - File name (required)
+# USAGE: cpdcb <filename>
+# EXAMPLE:
+#   cpdcb myfile.txt        # Copies full path of directory containing myfile.txt
+#   cpdcb /path/to/file.sh  # Copies /path/to
+#   cpdcb .                 # Copies current directory
+########################################################################################################################
+function _copy_directory_to_clipboard() {
+  local target="$1"
+  local dirpath
+  local clipboard_tool
+
+  # Check if argument is provided
+  if [[ -z "$target" ]]; then
+    _i_log_as_error "Please provide a file path. Usage: cpdcb <filename>"
+    return 1
+  fi
+
+  # Check if clipboard tool is available
+  clipboard_tool=$(_i_get_clipboard_tool)
+  if [[ -z "$clipboard_tool" ]]; then
+    _i_log_as_error "No clipboard tool found. Please install xclip, xsel, or pbcopy."
+    return 1
+  fi
+
+  # Check if the target exists
+  if [[ ! -e "$target" ]]; then
+    _i_log_as_error "File or directory '$target' does not exist."
+    return 1
+  fi
+
+  # Get the directory path
+  if [[ -d "$target" ]]; then
+    # If target is already a directory, use it directly
+    dirpath=$(realpath "$target" 2>/dev/null)
+    if [[ $? -ne 0 ]]; then
+      dirpath=$(cd "$target" && pwd)
+    fi
+  else
+    # If target is a file, get its directory
+    dirpath=$(realpath "$(dirname "$target")" 2>/dev/null)
+    if [[ $? -ne 0 ]]; then
+      dirpath=$(cd "$(dirname "$target")" && pwd)
+    fi
+  fi
+
+  # Copy to clipboard
+  echo -n "$dirpath" | eval "$clipboard_tool"
+  if [[ $? -eq 0 ]]; then
+    _i_log_as_info "Copied to clipboard: $dirpath"
+    _i_log_ok
+  else
+    _i_log_as_error "Failed to copy to clipboard."
+    return 1
+  fi
+}

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -197,6 +197,7 @@ alias c=_mark_folder_as_current
 alias cdf=_change_directory_from_filepath
 alias cf=_mark_file_as_current
 alias cpcb=_copy_fullpath_to_clipboard
+alias cpdcb=_copy_directory_to_clipboard
 alias ik=_interactive_kill
 alias sucd=_su_to_current_directory
 alias sn=_snapshot_file

--- a/src/main/help/help_files_folders
+++ b/src/main/help/help_files_folders
@@ -17,6 +17,7 @@ cf FILEPATH : mark file as current, use "gcf" to open it in vim from any place
 ------------------------------------------------------------------------------------------------------------------------
 Clipboard
 cpcb [FILEPATH] : copy full path of file to clipboard (defaults to current directory if no argument)
+cpdcb FILEPATH : copy full path of directory containing the file to clipboard
 ------------------------------------------------------------------------------------------------------------------------
 Safe delete
 [CTRL + X then E] display a safe rm command such as `rm -i -rf /tmp/qmt/anyfolder && cd..` to quickly delete current folder and to avoid `rm -rf *` in your bash history.


### PR DESCRIPTION
Add new cpdcb command that copies the directory containing a file to clipboard.
- Extended functions_clipboard.sh with _copy_directory_to_clipboard
- Added cpdcb alias in nixlper.sh
- Updated help documentation
- Handles both files and directories, resolves relative paths
- Requires file argument (unlike cpcb which defaults to current dir)