### PR TITLE
🤖 Add GitHub Action to auto-delete merged branches

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,43 @@
+# GitHub Actions
+
+This directory contains GitHub Actions workflows for automating repository tasks.
+
+## Workflows
+
+### Auto Delete Merged Branches
+
+**File:** `workflows/auto-delete-merged-branches.yml`
+
+**Purpose:** Automatically deletes feature branches after they are merged via pull request.
+
+**Triggers:** When a pull request is closed and merged
+
+**What it does:**
+1. Checks if the PR was actually merged (not just closed)
+2. Validates the branch is safe to delete (prevents deletion of main, master, develop, etc.)
+3. Deletes the merged branch from the remote repository
+4. Posts a comment on the PR confirming the deletion
+
+**Protected Branches:**
+The workflow will never delete these branches:
+- `main`
+- `master`
+- `develop` / `development`
+- Any branch starting with `release/`
+
+**Benefits:**
+- Keeps the repository clean by removing stale branches
+- Reduces manual cleanup work
+- Prevents branch clutter over time
+
+**Permissions Required:**
+- `contents: write` - To delete branches
+
+## Testing
+
+To test the workflow:
+1. Create a test branch
+2. Make a small change
+3. Create a pull request
+4. Merge the pull request
+5. Check that the branch is automatically deleted

--- a/.github/workflows/auto-delete-merged-branches.yml
+++ b/.github/workflows/auto-delete-merged-branches.yml
@@ -1,0 +1,62 @@
+name: Auto Delete Merged Branches
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-branch:
+    # Only run if the PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check branch name safety
+        id: check-branch
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          echo "Branch to delete: $BRANCH_NAME"
+
+          # Safety check: never delete main, master, develop, or release branches
+          if [[ "$BRANCH_NAME" == "main" ]] || \
+             [[ "$BRANCH_NAME" == "master" ]] || \
+             [[ "$BRANCH_NAME" == "develop" ]] || \
+             [[ "$BRANCH_NAME" == "development" ]] || \
+             [[ "$BRANCH_NAME" =~ ^release/.* ]]; then
+            echo "ERROR: Attempting to delete protected branch: $BRANCH_NAME"
+            echo "safe=false" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "Branch is safe to delete"
+            echo "safe=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Delete merged branch
+        if: steps.check-branch.outputs.safe == 'true'
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          echo "Deleting branch: $BRANCH_NAME"
+
+          # Delete the branch
+          git push origin --delete "$BRANCH_NAME" || {
+            echo "Failed to delete branch $BRANCH_NAME"
+            echo "This might be normal if the branch was already deleted"
+            exit 0
+          }
+
+          echo "Successfully deleted branch: $BRANCH_NAME"
+
+      - name: Comment on PR
+        if: steps.check-branch.outputs.safe == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🗑️ Branch `${{ github.event.pull_request.head.ref }}` has been automatically deleted after merge.'
+            })


### PR DESCRIPTION
Add workflow that automatically deletes feature branches after PR merge.

Features:
- Triggers on PR close (only if merged)
- Safety checks prevent deletion of protected branches (main, master, develop, release/*)
- Posts confirmation comment on PR
- Handles failures gracefully

This keeps the repository clean by removing stale branches automatically.