### PR TITLE
Fix GitHub Action to use API instead of git commands

### DIFF
--- a/.github/workflows/auto-delete-merged-branches.yml
+++ b/.github/workflows/auto-delete-merged-branches.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   delete-branch:
-    # Only run if the PR was merged (not just closed)
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
@@ -14,49 +13,36 @@ jobs:
       contents: write
 
     steps:
-      - name: Check branch name safety
-        id: check-branch
-        run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          echo "Branch to delete: $BRANCH_NAME"
-
-          # Safety check: never delete main, master, develop, or release branches
-          if [[ "$BRANCH_NAME" == "main" ]] || \
-             [[ "$BRANCH_NAME" == "master" ]] || \
-             [[ "$BRANCH_NAME" == "develop" ]] || \
-             [[ "$BRANCH_NAME" == "development" ]] || \
-             [[ "$BRANCH_NAME" =~ ^release/.* ]]; then
-            echo "ERROR: Attempting to delete protected branch: $BRANCH_NAME"
-            echo "safe=false" >> $GITHUB_OUTPUT
-            exit 1
-          else
-            echo "Branch is safe to delete"
-            echo "safe=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Delete merged branch
-        if: steps.check-branch.outputs.safe == 'true'
-        run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          echo "Deleting branch: $BRANCH_NAME"
-
-          # Delete the branch
-          git push origin --delete "$BRANCH_NAME" || {
-            echo "Failed to delete branch $BRANCH_NAME"
-            echo "This might be normal if the branch was already deleted"
-            exit 0
-          }
-
-          echo "Successfully deleted branch: $BRANCH_NAME"
-
-      - name: Comment on PR
-        if: steps.check-branch.outputs.safe == 'true'
+      - name: Check branch name safety and delete
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🗑️ Branch `${{ github.event.pull_request.head.ref }}` has been automatically deleted after merge.'
-            })
+            const branchName = context.payload.pull_request.head.ref;
+            console.log(`Branch to delete: ${branchName}`);
+
+            // Safety check: never delete main, master, develop, or release branches
+            const protectedBranches = ['main', 'master', 'develop', 'development'];
+            const isProtected = protectedBranches.includes(branchName) || branchName.startsWith('release/');
+
+            if (isProtected) {
+              core.setFailed(`ERROR: Attempting to delete protected branch: ${branchName}`);
+              return;
+            }
+
+            console.log('Branch is safe to delete');
+
+            // Delete the branch using GitHub API
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branchName}`
+              });
+              console.log(`Successfully deleted branch: ${branchName}`);
+            } catch (error) {
+              if (error.status === 422) {
+                console.log(`Branch ${branchName} was already deleted`);
+              } else {
+                core.setFailed(`Failed to delete branch: ${error.message}`);
+              }
+            }


### PR DESCRIPTION
- Use GitHub API (github.rest.git.deleteRef) instead of git push
- Remove comment step as requested
- Combine safety check and delete into single step
- Fix "not a git repository" error
- Better error handling for already-deleted branches