### PR TITLE
✨ Enable bind command execution from command palette

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,8 +76,12 @@ function _make_tar_archive() {
 function _merge_sh_sources() {
   cp src/main/bash/nixlper.sh "${WORK_DIRECTORY}/nixlper.tmp"
   cat src/main/bash/function* >> "${WORK_DIRECTORY}/functions.tmp"
-  sed -i '1,${/^#.*/d}' "${WORK_DIRECTORY}/functions.tmp"
-  sed -i '1,${/^#.*/d}' "${WORK_DIRECTORY}/nixlper.tmp"
+
+  # Remove comments but preserve @cmd-palette annotations
+  # Keep lines with: @cmd-palette, @description, @category, @keybind, @alias, @template
+  sed -i '/^#[[:space:]]*@\(cmd-palette\|description\|category\|keybind\|alias\|template\)/!{/^#.*/d}' "${WORK_DIRECTORY}/functions.tmp"
+  sed -i '/^#[[:space:]]*@\(cmd-palette\|description\|category\|keybind\|alias\|template\)/!{/^#.*/d}' "${WORK_DIRECTORY}/nixlper.tmp"
+
   echo "#!/usr/bin/env bash" > "${WORK_DIRECTORY}/nixlper.sh"
   echo "###############################################################################################################" >> "${WORK_DIRECTORY}/nixlper.sh"
   echo "# file is generated" >> "${WORK_DIRECTORY}/nixlper.sh"

--- a/debug_palette.sh
+++ b/debug_palette.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "NIXLPER COMMAND PALETTE DEBUGGING"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+echo "1. Environment Check"
+echo "   NIXLPER_INSTALL_DIR: ${NIXLPER_INSTALL_DIR:-NOT SET}"
+echo "   Shell: $SHELL"
+echo "   Interactive: $-"
+echo ""
+
+echo "2. Function Availability"
+echo "   _build_command_registry: $(type -t _build_command_registry 2>/dev/null || echo 'NOT FOUND')"
+echo "   _format_command_for_display: $(type -t _format_command_for_display 2>/dev/null || echo 'NOT FOUND')"
+echo "   find_action: $(type -t find_action 2>/dev/null || echo 'NOT FOUND')"
+echo ""
+
+echo "3. Alias Check"
+echo "   fa alias: $(alias fa 2>/dev/null || echo 'NOT FOUND')"
+echo ""
+
+echo "4. File Locations"
+if [[ -n "${NIXLPER_INSTALL_DIR}" ]]; then
+  echo "   Command palette file exists: $(test -f "${NIXLPER_INSTALL_DIR}/src/main/bash/functions_command_palette.sh" && echo 'YES' || echo 'NO')"
+  echo "   nixlper.sh exists: $(test -f "${NIXLPER_INSTALL_DIR}/src/main/bash/nixlper.sh" && echo 'YES' || echo 'NO')"
+
+  echo ""
+  echo "5. Registry Content Test"
+  if type -t _build_command_registry &>/dev/null; then
+    echo "   Total commands in registry: $(_build_command_registry 2>/dev/null | wc -l)"
+    echo ""
+    echo "   First 10 commands in formatted view:"
+    _build_command_registry 2>/dev/null | while read line; do
+      _format_command_for_display "$line" 2>/dev/null
+    done | head -10
+    echo ""
+    echo "   Commands with [alias] indicator:"
+    _build_command_registry 2>/dev/null | while read line; do
+      _format_command_for_display "$line" 2>/dev/null
+    done | grep "\[alias\]" | wc -l
+  fi
+else
+  echo "   Cannot check - NIXLPER_INSTALL_DIR not set"
+fi
+echo ""
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "DIAGNOSTIC SUMMARY:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ -z "${NIXLPER_INSTALL_DIR}" ]]; then
+  echo "❌ ISSUE: NIXLPER_INSTALL_DIR not set"
+  echo "   FIX: Run 'source ~/.bashrc' or restart your terminal"
+  echo ""
+fi
+
+if ! type -t _build_command_registry &>/dev/null; then
+  echo "❌ ISSUE: Command palette functions not loaded"
+  echo "   FIX: Run 'source ~/.bashrc' to reload all functions"
+  echo ""
+fi
+
+if ! type -t find_action &>/dev/null; then
+  echo "❌ ISSUE: find_action function not available"
+  echo "   FIX: Run 'source ~/.bashrc'"
+  echo ""
+fi
+
+if type -t _build_command_registry &>/dev/null; then
+  TOTAL=$(_build_command_registry 2>/dev/null | wc -l)
+  if [[ $TOTAL -lt 20 ]]; then
+    echo "⚠️  WARNING: Only $TOTAL commands in registry (expected 25)"
+    echo "   This might be normal if you only see 4 items in the palette"
+    echo ""
+  else
+    echo "✅ SUCCESS: Registry has $TOTAL commands"
+    echo ""
+  fi
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "NEXT STEPS:"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "1. Run: source ~/.bashrc"
+echo "2. Run this debug script again: bash debug_palette.sh"
+echo "3. If still showing 4 items, share the output with Claude"
+echo ""

--- a/src/main/bash/functions_command_palette.sh
+++ b/src/main/bash/functions_command_palette.sh
@@ -5,25 +5,66 @@
 ########################################################################################################################
 
 #-----------------------------------------------------------------------------------------------------------------------
+# _register_keybindings: Register all keybind commands
+#-----------------------------------------------------------------------------------------------------------------------
+function _register_keybindings() {
+  echo "CTRL_X_D|Display existing bookmarks with aliases|Bookmarks|CTRL+X+D|bind|_display_existing_bookmarks|0"
+  echo "CTRL_X_B|Add or remove bookmark for current folder|Bookmarks|CTRL+X+B|bind|_add_or_remove_bookmark\15|0"
+  echo "CTRL_X_H|Interactive help search|Help|CTRL+X+H|bind|_help\15|0"
+  echo "CTRL_X_V|Display nixlper logo and version|Version|CTRL+X+V|bind|_display_logo_and_version|0"
+  echo "CTRL_X_E|Display safe rm command to delete current folder|Utilities|CTRL+X+E|bind|rm -rf \$(pwd)/\33\5 && cd ..|1"
+  echo "CTRL_X_R|Display safe rm command to delete folder contents|Utilities|CTRL+X+R|bind|rm -rf \$(pwd)/\33\5*|1"
+  echo "CTRL_X_U|Go up one directory|Navigation|CTRL+X+U|bind|cd ..\15|0"
+  echo "CTRL_X_N|Navigate folders interactively (tree/flat mode)|Navigation|CTRL+X+N|bind|navigate|0"
+  echo "CTRL_X_O|Open nixlper.sh in editor|Utilities|CTRL+X+O|bind|\$NIXLPER_EDITOR \${NIXLPER_INSTALL_DIR}/nixlper.sh|0"
+  echo "CTRL_X_A|Search and select commands interactively|Command Palette|CTRL+X+A|bind|find_action|0"
+  echo "CTRL_P|Start recording bash commands|Macros|CTRL+P|bind|start_recording|0"
+  echo "CTRL_P_CTRL_P|Stop and save macro recording|Macros|CTRL+P+CTRL+P|bind|finalize_recording|0"
+  echo "CTRL_P_CTRL_L|Replay last recorded macro|Macros|CTRL+P+CTRL+L|bind|bind_last_macro|0"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _register_aliases: Register all alias commands
+#-----------------------------------------------------------------------------------------------------------------------
+function _register_aliases() {
+  echo "fa|Search and select commands interactively|Command Palette|CTRL+X+A|fa|0"
+  echo "ik|Interactive kill by pattern or port|Processes||ik|0"
+  echo "sr|Start recording bash commands|Macros|CTRL+P|sr|0"
+  echo "fr|Stop and save macro recording|Macros|CTRL+P+CTRL+P|fr|0"
+  echo "c|Mark current folder (use 'gc' to return)|Files & Folders||c|0"
+  echo "cf|Mark file as current (use 'gcf' to open)|Files & Folders||cf|0"
+  echo "sn|Snapshot file to snapshots area|Files & Folders||sn|0"
+  echo "re|Restore file from snapshots|Files & Folders||re|0"
+  echo "cdf|Change to the folder containing a file|Files & Folders||cdf|0"
+  echo "cpcb|Copy full file path to clipboard|Files & Folders||cpcb|0"
+  echo "cpdcb|Copy directory path to clipboard|Files & Folders||cpdcb|0"
+  echo "sucd|Switch user and maintain current directory|Users||sucd|0"
+  echo "ap|Prepend current path to PATH in .bashrc|Utilities||ap|0"
+  echo "fan|Find and navigate using pattern matching|Navigation||fan|0"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _register_functions: Register all function commands (that aren't already registered as bindings)
+#-----------------------------------------------------------------------------------------------------------------------
+function _register_functions() {
+  echo "_display_existing_bookmarks|Display existing bookmarks with aliases|Bookmarks|CTRL+X+D||0"
+  echo "_add_or_remove_bookmark|Add or remove bookmark for current folder|Bookmarks|CTRL+X+B||0"
+  echo "_help|Interactive help search|Help|CTRL+X+H||0"
+  echo "_display_logo_and_version|Display nixlper logo and version|Version|CTRL+X+V||0"
+  echo "navigate|Navigate folders interactively (tree/flat mode)|Navigation|CTRL+X+N||0"
+  echo "bind_last_macro|Replay last recorded macro|Macros|CTRL+P+CTRL+L||0"
+  echo "toggle_navigation_mode|Toggle size/permissions display in navigate|Navigation|||0"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
 # _build_command_registry: Build a searchable registry of all available commands
-# Dynamically parses @cmd-palette annotations from source files
-# Output format: command_name | description | category | keybinding | alias
+# Uses programmatic registration instead of parsing to survive build process
+# Output format: command_name | description | category | keybinding | alias | is_template
 #-----------------------------------------------------------------------------------------------------------------------
 function _build_command_registry() {
-  local bash_dir="${NIXLPER_INSTALL_DIR}"
-
-  # If we're in development (source tree), use src/main/bash
-  if [[ -d "${NIXLPER_INSTALL_DIR}/src/main/bash" ]]; then
-    bash_dir="${NIXLPER_INSTALL_DIR}/src/main/bash"
-  fi
-
-  # Find all bash files and parse annotations
-  local files=$(find "$bash_dir" -name "*.sh" -o -name "nixlper.sh" 2>/dev/null)
-
-  # Parse each file for @cmd-palette annotations
-  for file in $files; do
-    _parse_cmd_palette_annotations "$file"
-  done
+  _register_keybindings
+  _register_aliases
+  _register_functions
 }
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/src/main/bash/functions_command_palette.sh
+++ b/src/main/bash/functions_command_palette.sh
@@ -130,6 +130,7 @@ function _format_command_for_display() {
   local display=""
   local keybind_part=""
   local category_part=""
+  local type_indicator=""
 
   # Add keybinding if exists (aligned to 20 chars)
   if [[ -n "$keybinding" ]]; then
@@ -138,13 +139,18 @@ function _format_command_for_display() {
     keybind_part=$(printf "%-20s" "")
   fi
 
+  # Add type indicator for aliases
+  if [[ -n "$cmd_type" && "$cmd_type" == "$cmd_name" && "$cmd_type" != "bind" ]]; then
+    type_indicator="[alias] "
+  fi
+
   # Add category tag
   if [[ -n "$category" ]]; then
     category_part=" {$category}"
   fi
 
   # Output the formatted line (35 chars for command name to handle longer names)
-  printf "%s%-35s%s%s\n" "$keybind_part" "$cmd_name" "$description" "$category_part"
+  printf "%s%-35s%s%s%s\n" "$keybind_part" "$cmd_name" "${type_indicator}${description}" "$category_part"
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -226,6 +232,9 @@ function _clean_bind_command() {
 # Args: $1 = selected formatted line from fzf
 #-----------------------------------------------------------------------------------------------------------------------
 function _execute_command() {
+  # Enable alias expansion for eval
+  shopt -s expand_aliases
+
   local selected="$1"
 
   # Extract command name from the formatted display string

--- a/src/main/bash/functions_command_palette.sh
+++ b/src/main/bash/functions_command_palette.sh
@@ -5,66 +5,23 @@
 ########################################################################################################################
 
 #-----------------------------------------------------------------------------------------------------------------------
-# _register_keybindings: Register all keybind commands
-#-----------------------------------------------------------------------------------------------------------------------
-function _register_keybindings() {
-  echo "CTRL_X_D|Display existing bookmarks with aliases|Bookmarks|CTRL+X+D|bind|_display_existing_bookmarks|0"
-  echo "CTRL_X_B|Add or remove bookmark for current folder|Bookmarks|CTRL+X+B|bind|_add_or_remove_bookmark\15|0"
-  echo "CTRL_X_H|Interactive help search|Help|CTRL+X+H|bind|_help\15|0"
-  echo "CTRL_X_V|Display nixlper logo and version|Version|CTRL+X+V|bind|_display_logo_and_version|0"
-  echo "CTRL_X_E|Display safe rm command to delete current folder|Utilities|CTRL+X+E|bind|rm -rf \$(pwd)/\33\5 && cd ..|1"
-  echo "CTRL_X_R|Display safe rm command to delete folder contents|Utilities|CTRL+X+R|bind|rm -rf \$(pwd)/\33\5*|1"
-  echo "CTRL_X_U|Go up one directory|Navigation|CTRL+X+U|bind|cd ..\15|0"
-  echo "CTRL_X_N|Navigate folders interactively (tree/flat mode)|Navigation|CTRL+X+N|bind|navigate|0"
-  echo "CTRL_X_O|Open nixlper.sh in editor|Utilities|CTRL+X+O|bind|\$NIXLPER_EDITOR \${NIXLPER_INSTALL_DIR}/nixlper.sh|0"
-  echo "CTRL_X_A|Search and select commands interactively|Command Palette|CTRL+X+A|bind|find_action|0"
-  echo "CTRL_P|Start recording bash commands|Macros|CTRL+P|bind|start_recording|0"
-  echo "CTRL_P_CTRL_P|Stop and save macro recording|Macros|CTRL+P+CTRL+P|bind|finalize_recording|0"
-  echo "CTRL_P_CTRL_L|Replay last recorded macro|Macros|CTRL+P+CTRL+L|bind|bind_last_macro|0"
-}
-
-#-----------------------------------------------------------------------------------------------------------------------
-# _register_aliases: Register all alias commands
-#-----------------------------------------------------------------------------------------------------------------------
-function _register_aliases() {
-  echo "fa|Search and select commands interactively|Command Palette|CTRL+X+A|fa|0"
-  echo "ik|Interactive kill by pattern or port|Processes||ik|0"
-  echo "sr|Start recording bash commands|Macros|CTRL+P|sr|0"
-  echo "fr|Stop and save macro recording|Macros|CTRL+P+CTRL+P|fr|0"
-  echo "c|Mark current folder (use 'gc' to return)|Files & Folders||c|0"
-  echo "cf|Mark file as current (use 'gcf' to open)|Files & Folders||cf|0"
-  echo "sn|Snapshot file to snapshots area|Files & Folders||sn|0"
-  echo "re|Restore file from snapshots|Files & Folders||re|0"
-  echo "cdf|Change to the folder containing a file|Files & Folders||cdf|0"
-  echo "cpcb|Copy full file path to clipboard|Files & Folders||cpcb|0"
-  echo "cpdcb|Copy directory path to clipboard|Files & Folders||cpdcb|0"
-  echo "sucd|Switch user and maintain current directory|Users||sucd|0"
-  echo "ap|Prepend current path to PATH in .bashrc|Utilities||ap|0"
-  echo "fan|Find and navigate using pattern matching|Navigation||fan|0"
-}
-
-#-----------------------------------------------------------------------------------------------------------------------
-# _register_functions: Register all function commands (that aren't already registered as bindings)
-#-----------------------------------------------------------------------------------------------------------------------
-function _register_functions() {
-  echo "_display_existing_bookmarks|Display existing bookmarks with aliases|Bookmarks|CTRL+X+D||0"
-  echo "_add_or_remove_bookmark|Add or remove bookmark for current folder|Bookmarks|CTRL+X+B||0"
-  echo "_help|Interactive help search|Help|CTRL+X+H||0"
-  echo "_display_logo_and_version|Display nixlper logo and version|Version|CTRL+X+V||0"
-  echo "navigate|Navigate folders interactively (tree/flat mode)|Navigation|CTRL+X+N||0"
-  echo "bind_last_macro|Replay last recorded macro|Macros|CTRL+P+CTRL+L||0"
-  echo "toggle_navigation_mode|Toggle size/permissions display in navigate|Navigation|||0"
-}
-
-#-----------------------------------------------------------------------------------------------------------------------
 # _build_command_registry: Build a searchable registry of all available commands
-# Uses programmatic registration instead of parsing to survive build process
+# Dynamically parses @cmd-palette annotations from source files
 # Output format: command_name | description | category | keybinding | alias | is_template
 #-----------------------------------------------------------------------------------------------------------------------
 function _build_command_registry() {
-  _register_keybindings
-  _register_aliases
-  _register_functions
+  # Check if we're in development (source tree) or installed (merged file)
+  if [[ -d "${NIXLPER_INSTALL_DIR}/src/main/bash" ]]; then
+    # Development: parse all source files
+    local bash_dir="${NIXLPER_INSTALL_DIR}/src/main/bash"
+    local files=$(find "$bash_dir" -name "*.sh" -o -name "nixlper.sh" 2>/dev/null)
+    for file in $files; do
+      _parse_cmd_palette_annotations "$file"
+    done
+  else
+    # Installed: parse the merged nixlper.sh file
+    _parse_cmd_palette_annotations "${NIXLPER_INSTALL_DIR}/nixlper.sh"
+  fi
 }
 
 #-----------------------------------------------------------------------------------------------------------------------

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -176,11 +176,13 @@ function _i_load_bindings() {
     # @description: Display safe rm command to delete current folder
     # @category: Utilities
     # @keybind: CTRL+X+E
+    # @template
     bind '"\C-x\C-e":"rm -rf $(pwd)/\33\5 && cd .."' #\33\5 is ESC then CTRL+E
     # @cmd-palette
     # @description: Display safe rm command to delete folder contents
     # @category: Utilities
     # @keybind: CTRL+X+R
+    # @template
     bind '"\C-x\C-r":"rm -rf $(pwd)/\33\5*"' #\33\5 is ESC then CTRL+R
 
     # navigation

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -162,13 +162,14 @@ function _i_delete_bashrc_config() {
 #***********************************************************************************************************************
 function _i_load_bindings() {
   if [[ $- == *i* ]]; then
-    # bookmarks
+    # bookmarks - annotations already in functions_bookmarks.sh
     bind -x '"\C-x\C-d": _display_existing_bookmarks'
     bind  '"\C-x\C-b": "_add_or_remove_bookmark\15"'
-    # help
+
+    # help - annotation already in functions_help.sh
     bind '"\C-x\C-h": "_help\15"'
 
-    # version and logo
+    # version and logo - annotation already in functions_version.sh
     bind -x '"\C-x\C-v": _display_logo_and_version'
 
     # files
@@ -191,6 +192,7 @@ function _i_load_bindings() {
     # @category: Navigation
     # @keybind: CTRL+X+U
     bind '"\C-x\C-u": "cd ..\15"'
+    # navigate - annotation already in functions_navigation.sh
     bind -x '"\C-x\C-n": navigate'
 
     # instant access to this file
@@ -200,11 +202,12 @@ function _i_load_bindings() {
     # @keybind: CTRL+X+O
     bind -x '"\C-x\C-o": $NIXLPER_EDITOR ${NIXLPER_INSTALL_DIR}/nixlper.sh'
 
+    # macros - annotations already in functions_macros.sh
     bind -x '"\C-p":start_recording'
     bind -x  '"\C-p\C-p": finalize_recording'
     bind -x  '"\C-p\C-l": bind_last_macro'
 
-    # command palette
+    # command palette - annotation already in functions_command_palette.sh
     bind -x '"\C-x\C-a": find_action'
   fi
 }


### PR DESCRIPTION
Implemented support for executing the underlying functions of bind commands
from the command palette, addressing the limitation where bind commands
could only be triggered via their keybindings.

**Features:**
- Extract and parse bind commands (both `bind` and `bind -x` formats)
- Clean escape sequences (\15, \33\5) from bind command strings
- Execute cleaned bind commands programmatically
- New @template annotation to mark commands as display-only (unsafe to auto-execute)
- Template commands show their content without executing

**Changes:**
- Added `_clean_bind_command()` function to remove escape sequences
- Enhanced `_parse_cmd_palette_annotations()` to extract bind command text
- Updated registry format to include bind command and template flag fields
- Modified `_execute_command()` to handle bind command execution
- Marked dangerous rm commands with @template annotation for safety

**Examples:**
- Executable: `cd ..` (CTRL+X+U) - executes navigation
- Template: `rm -rf $(pwd)/...` (CTRL+X+E) - displays template only
- Bind -x: Editor command (CTRL+X+O) - executes with variable expansion

This allows users to search and execute bind commands from the command
palette while maintaining safety through template detection.