### PR TITLE
Add grep-and-navigate function with file opening shortcuts

### DIFF
--- a/src/main/bash/functions_navigation.sh
+++ b/src/main/bash/functions_navigation.sh
@@ -207,6 +207,47 @@ function _find_and_navigate() {
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
+# _grep_and_navigate: execute "grep -rn PATTERN ." then display results with shortcuts to open files at matching lines
+# @cmd-palette
+# @description: Grep files for pattern and open file at matching line
+# @category: Navigation
+# @alias: fag
+#-----------------------------------------------------------------------------------------------------------------------
+function _grep_and_navigate() {
+  if [[ $# -eq 0 ]]; then
+    _i_log_as_error "Missing pattern for grep_and_navigate"
+    return 1
+  elif [[ -z $1 ]]; then
+    _i_log_as_error "Pattern cannot be empty for grep_and_navigate"
+    return 1
+  else
+    local grep_results
+    grep_results=$(grep -rn "$*" . 2>/dev/null)
+    local item_increment=1
+    if [[ -n ${grep_results} ]]; then
+      echo ".."
+      local file_path
+      local line_number
+      local matched_content
+      IFS=$'\n'
+      for i in ${grep_results}; do
+        file_path=$(echo "$i" | cut -d':' -f1)
+        line_number=$(echo "$i" | cut -d':' -f2)
+        matched_content=$(echo "$i" | cut -d':' -f3-)
+        # shellcheck disable=SC2139
+        alias v${item_increment}="$NIXLPER_EDITOR +${line_number} ${file_path}"
+        echo "${file_path}:${line_number}:${matched_content} → v${item_increment}"
+        ((item_increment++))
+      done
+      unset IFS
+      echo ".."
+    else
+      echo "No match"
+    fi
+  fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
 # _toggle_size_display_during_navigation: enable/disable size display during navigate call
 # @cmd-palette
 # @description: Toggle size/permissions display in navigate

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -228,6 +228,7 @@ alias sucd=_su_to_current_directory
 alias sn=_snapshot_file
 alias re=_restore_file
 alias fan=_find_and_navigate
+alias fag=_grep_and_navigate
 alias olf=_open_latest_file
 # Prepend current path in PATH variable updating the .bashrc if not already done
 # @cmd-palette


### PR DESCRIPTION
## Summary
Added a new `_grep_and_navigate` function that enables users to search for patterns across files and quickly open matching files at the exact line numbers where matches occur.

## Key Changes
- **New function `_grep_and_navigate`**: Executes `grep -rn` to recursively search for a pattern in the current directory and displays results with numbered shortcuts
  - Validates that a pattern is provided (non-empty)
  - Parses grep output to extract file path, line number, and matched content
  - Dynamically creates aliases (v1, v2, etc.) that open files in the configured editor at the matching line numbers
  - Displays results in a user-friendly format with visual separators
  - Handles cases where no matches are found
  
- **New alias `fag`**: Maps to `_grep_and_navigate` for quick access from the command line

- **Command palette support**: Function includes metadata annotations (`@cmd-palette`, `@description`, `@category`, `@alias`) for integration with command palette features

## Implementation Details
- Uses `grep -rn` with error suppression (`2>/dev/null`) to search recursively with line numbers
- Parses colon-delimited grep output using `cut` to extract file path, line number, and content
- Dynamically creates shell aliases using `shellcheck disable=SC2139` to suppress warnings about dynamic alias creation
- Properly handles multi-word patterns by using `"$*"` to preserve the full search string
- Manages IFS (Internal Field Separator) to correctly iterate over newline-separated grep results

https://claude.ai/code/session_01WZ9vNuk3LaEkRTzinoVWcE