### PR TITLE
Add RPM packaging and multi-install method support

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -1,17 +1,27 @@
 # Nixlper - Project Context
 
+## Meta — Keeping This File Current
+
+Update this file whenever a session introduces something a future session would need to know:
+new files or directories, architectural decisions, new env variables, build steps, or constraints
+discovered during implementation. The goal is that any new session can start from this file
+without re-discovering context.
+
+---
+
 ## Project Overview
 Nixlper is a bash helper inspired by Total Commander for Unix/Linux environments. Provides keyboard-driven file navigation, bookmarks, macros, and process management.
 
 **Philosophy:**
 - Keyboard shortcuts inspired by Total Commander
 - Modular development, unified distribution
-- Simple installation (install/update/uninstall)
+- Multiple installation methods (manual tar, RPM, DEB planned)
 - Safety-first approach (confirmations, rm -i)
 
 **Build Flow:**
 ```
 src/main/bash/*.sh → build.sh → build/distributions/nixlper-*.tar
+                              → build-rpm.sh → ~/rpmbuild/RPMS/noarch/nixlper-*.rpm
 ```
 
 ---
@@ -23,7 +33,15 @@ nixlper/
 ├── src/main/bash/          # Individual bash modules
 │   ├── nixlper.sh          # Main entry point
 │   └── functions_*.sh      # Feature modules
-├── build.sh                # Build script (concatenation + packaging)
+├── build.sh                # Build script (concatenation + tar packaging)
+├── build-rpm.sh            # RPM build script (calls build.sh, then rpmbuild)
+├── install.sh              # Manual tar-based installer (downloads from GitHub releases)
+├── packaging/
+│   ├── shared/
+│   │   ├── nixlper.conf          # System config deployed by RPM/DEB to /etc/nixlper/
+│   │   └── nixlper-profile.d.sh  # profile.d loader deployed to /etc/profile.d/nixlper.sh
+│   └── rpm/
+│       └── nixlper.spec          # RPM spec file
 └── .claude/                # AI context files
 ```
 
@@ -108,24 +126,99 @@ bind -x '"\C-x\C-y": your_function_name'  # CTRL+X then Y
 
 ## Build & Installation
 
-### Build
-`build.sh` concatenates all `src/main/bash/function*.sh` files, merges with `nixlper.sh`, and creates `nixlper-VERSION.tar` in `build/distributions/`
+### Build tar (all platforms)
+`build.sh` concatenates all `src/main/bash/function*.sh` files, merges with `nixlper.sh`,
+strips comments (preserving `@cmd-palette` annotations), and creates `nixlper-VERSION.tar`
+in `build/distributions/`. Requires `dos2unix`.
 
-### Install/Update/Uninstall
+### Manual install (tar-based, any Unix)
 ```bash
-./nixlper.sh install    # Updates ~/.bashrc, creates ~/.nixlper/
-./nixlper.sh update     # Preserves user data
-./nixlper.sh uninstall  # Removes from ~/.bashrc
+bash build.sh
+mkdir -p /opt/nixlper && tar -xf build/distributions/nixlper.tar -C /opt/nixlper
+cd /opt/nixlper && ./nixlper.sh install   # writes to ~/.bashrc
+source ~/.bashrc
+```
+
+### Update / Uninstall (manual)
+```bash
+./nixlper.sh update     # rewrites ~/.bashrc block, preserves user data
+./nixlper.sh uninstall  # removes ~/.bashrc block
+```
+
+### Build RPM (RHEL/Fedora/Rocky — requires rpm-build)
+```bash
+bash build-rpm.sh
+# RPM lands in ~/rpmbuild/RPMS/noarch/
 ```
 
 ---
 
 ## Environment Variables
 
-Set in `~/.bashrc` after installation:
-- `NIXLPER_INSTALL_DIR`: Installation directory
-- `NIXLPER_NAVIGATE_MODE`: tree|flat
-- `NIXLPER_EDITOR`: Editor to use (default: vim)
+All variables follow a precedence chain — later sources override earlier ones:
+
+1. `/etc/nixlper/nixlper.conf` — system defaults (RPM/DEB managed, uses `:-` so it never overrides vars already set by `~/.bashrc`)
+2. `~/.config/nixlper/nixlper.conf` — per-user overrides
+3. `~/.bashrc` — manual install sets vars here before sourcing nixlper.sh
+
+| Variable | Manual install default | RPM/DEB default |
+|---|---|---|
+| `NIXLPER_INSTALL_DIR` | user-chosen dir (e.g. `/opt/nixlper`) | `/usr/share/nixlper` |
+| `NIXLPER_BOOKMARKS_FILE` | `$NIXLPER_INSTALL_DIR/.nixlper_bookmarks` | `~/.local/share/nixlper/bookmarks` |
+| `NIXLPER_LAST_MACRO_BINDING_FILE` | `$NIXLPER_INSTALL_DIR/.nixlper_last_macro_binding_file` | `~/.local/share/nixlper/last_macro_binding` |
+| `NIXLPER_SNAPSHOT_DIR` | `$NIXLPER_INSTALL_DIR/snapshots` | `~/.local/share/nixlper/snapshots` |
+| `NIXLPER_CUSTOM_DIR` | `$NIXLPER_INSTALL_DIR/custom` | `~/.config/nixlper/custom` |
+| `NIXLPER_NAVIGATE_MODE` | `tree` | `tree` |
+| `NIXLPER_EDITOR` | `vim` | `vim` |
+| `NIXLPER_DISABLE_WELCOME_MESSAGE` | `false` | `false` |
+
+`NIXLPER_SNAPSHOT_DIR` and `NIXLPER_CUSTOM_DIR` are resolved inside nixlper.sh with `:-` fallbacks
+to `$NIXLPER_INSTALL_DIR/snapshots` and `$NIXLPER_INSTALL_DIR/custom` when not explicitly set.
+
+---
+
+## RPM Packaging
+
+### How it works
+- `/etc/profile.d/nixlper.sh` (single line: `source /usr/share/nixlper/nixlper.sh`) activates nixlper for all users at login — no `.bashrc` changes needed.
+- nixlper.sh itself loads the config chain: `/etc/nixlper/nixlper.conf` then `~/.config/nixlper/nixlper.conf`.
+- User data (`bookmarks`, `snapshots/`, `custom/`) is created on first login under `~/.local/share/nixlper/` and `~/.config/nixlper/` — never owned or modified by the RPM.
+
+### Building the RPM
+```bash
+# Requires: rpmbuild (dnf install rpm-build on RHEL/Fedora/Rocky)
+bash build-rpm.sh
+# Output: ~/rpmbuild/RPMS/noarch/nixlper-VERSION-1.noarch.rpm
+```
+
+### Install / upgrade / uninstall
+```bash
+dnf install nixlper-VERSION.noarch.rpm   # first install
+dnf upgrade nixlper-VERSION.noarch.rpm   # upgrade — /etc/nixlper/nixlper.conf preserved
+dnf remove nixlper                        # uninstall — user data untouched
+```
+
+### Key RPM spec decisions
+- `BuildArch: noarch` — pure bash, no compilation
+- `%config(noreplace)` on `/etc/nixlper/nixlper.conf` — admin edits survive upgrades
+- `/etc/profile.d/nixlper.sh` is NOT `%config` — it is always replaced on upgrade
+- `Requires: bash >= 4.0` / `Recommends: vim, tree`
+- `%post` and `%preun` are intentionally empty
+
+### Compatibility with manual install
+The same `nixlper.sh` binary supports both install methods. When `/etc/nixlper/nixlper.conf`
+is absent (manual install), all vars fall back to `NIXLPER_INSTALL_DIR`-relative paths.
+The double-load guard (`NIXLPER_LOADED`) prevents double initialisation if both `.bashrc`
+and profile.d are active simultaneously during migration.
+
+---
+
+## DEB Packaging
+
+Native DEB is planned (next session). Key difference from alien-converted DEB:
+- Only `/etc/nixlper/nixlper.conf` should be listed in `DEBIAN/conffiles` (admin-editable).
+- `/etc/profile.d/nixlper.sh` must NOT be a conffile — it should be removed cleanly on `dpkg -r`.
+- Shared source files: `packaging/shared/nixlper.conf` and `packaging/shared/nixlper-profile.d.sh`.
 
 ---
 
@@ -134,4 +227,5 @@ Set in `~/.bashrc` after installation:
 - [ ] Test in Git Bash and Linux
 - [ ] Validate keyboard bindings
 - [ ] Run shellcheck if safe
-- [ ] Test build and installation
+- [ ] Test build and installation (`bash build.sh && tar -xf ... && ./nixlper.sh install`)
+- [ ] RPM: `bash build-rpm.sh` on a RHEL/Fedora/Rocky system, then `dnf install`

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: build-deb.sh
+# DESCRIPTION: Build a nixlper DEB package for Ubuntu/Debian.
+#              Requires: dpkg-deb (standard on any Debian-based system)
+########################################################################################################################
+set -o nounset
+set -o errexit
+set -o pipefail
+
+readonly SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+_log_separator() { echo "====================================================================================="; }
+_log_info()  { echo "ℹ️  $1"; }
+_log_ok()    { echo "✅ $1"; }
+_log_error() { echo "❌ $1" >&2; }
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Version — strip leading 'v' from git tag (e.g. v1.2.3 → 1.2.3).
+# Fallback to short SHA for dev builds.
+#-----------------------------------------------------------------------------------------------------------------------
+_get_version() {
+  local tag
+  tag=$(git describe --tags --exact-match HEAD 2>/dev/null | sed 's/^v//' || true)
+  if [[ -n "${tag}" ]]; then
+    echo "${tag}"
+  else
+    # DEB version must start with a digit; prefix dev SHA with 0~
+    echo "0~$(git log -n 1 --pretty=format:%h)"
+  fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Locate the tar produced by build.sh
+#-----------------------------------------------------------------------------------------------------------------------
+_get_tar_path() {
+  local -r version="$1"
+  local -r versioned="${SCRIPT_DIR}/build/distributions/nixlper-${version}.tar"
+  local -r unversioned="${SCRIPT_DIR}/build/distributions/nixlper.tar"
+  if [[ -f "${versioned}" ]]; then
+    echo "${versioned}"
+  elif [[ -f "${unversioned}" ]]; then
+    echo "${unversioned}"
+  else
+    _log_error "No tar found in build/distributions/ — run build.sh first"
+    return 1
+  fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Main
+#-----------------------------------------------------------------------------------------------------------------------
+main() {
+  _log_separator
+  _log_info "Build nixlper DEB"
+  _log_separator
+
+  if ! command -v dpkg-deb &>/dev/null; then
+    _log_error "dpkg-deb not found — install the dpkg package"
+    exit 1
+  fi
+
+  local -r version=$(_get_version)
+  _log_info "Version: ${version}"
+
+  # Build the bash tar first
+  _log_info "Building nixlper tar..."
+  bash "${SCRIPT_DIR}/build.sh"
+  _log_ok "Tar built"
+
+  local -r tar_path=$(_get_tar_path "${version}")
+  _log_info "Using tar: ${tar_path}"
+
+  # Set up clean staging tree
+  local -r staging="${SCRIPT_DIR}/build/deb/nixlper_${version}_all"
+  rm -rf "${staging}"
+  mkdir -p "${staging}/DEBIAN"
+  mkdir -p "${staging}/usr/share/nixlper/help"
+  mkdir -p "${staging}/usr/share/doc/nixlper"
+  mkdir -p "${staging}/etc/nixlper"
+  mkdir -p "${staging}/etc/profile.d"
+
+  # Scripts and help files
+  tar -xf "${tar_path}" -C "${staging}/usr/share/nixlper"
+  chmod 644 "${staging}/usr/share/nixlper/nixlper.sh"
+  chmod 644 "${staging}/usr/share/nixlper/version"
+  chmod 644 "${staging}/usr/share/nixlper/help/"*
+
+  # System config — admin-editable, preserved on upgrade
+  install -m 644 "${SCRIPT_DIR}/packaging/shared/nixlper.conf" \
+    "${staging}/etc/nixlper/nixlper.conf"
+
+  # profile.d loader — one line, activates nixlper for all users at login
+  install -m 644 "${SCRIPT_DIR}/packaging/shared/nixlper-profile.d.sh" \
+    "${staging}/etc/profile.d/nixlper.sh"
+
+  # DEBIAN/control
+  cat > "${staging}/DEBIAN/control" <<EOF
+Package: nixlper
+Version: ${version}
+Architecture: all
+Maintainer: Quang-Minh TRAN <qgmh.tran@gmail.com>
+Depends: bash (>= 4.0)
+Recommends: vim, tree
+Description: Bash helper for keyboard-driven file and directory management
+ Nixlper provides directory bookmarks, navigation, file operations, process
+ management, macros, clipboard support, and a command palette for the shell.
+ .
+ Activated automatically for all users via /etc/profile.d/nixlper.sh.
+ System defaults in /etc/nixlper/nixlper.conf (preserved on upgrade).
+ Per-user overrides in ~/.config/nixlper/nixlper.conf.
+EOF
+
+  # DEBIAN/conffiles — only nixlper.conf is preserved on upgrade.
+  # profile.d is intentionally NOT listed: it is always replaced on upgrade
+  # and removed cleanly on dpkg -r.
+  cat > "${staging}/DEBIAN/conffiles" <<EOF
+/etc/nixlper/nixlper.conf
+EOF
+
+  # copyright (required by Debian policy)
+  cat > "${staging}/usr/share/doc/nixlper/copyright" <<EOF
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: nixlper
+Upstream-Contact: Quang-Minh TRAN <qgmh.tran@gmail.com>
+Source: https://github.com/Minhounet/nixlper
+
+Files: *
+Copyright: 2023 Quang-Minh TRAN
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+EOF
+
+  _log_ok "Staging tree ready"
+
+  # Build the .deb
+  local -r output_dir="${SCRIPT_DIR}/build/distributions"
+  local -r deb_path="${output_dir}/nixlper_${version}_all.deb"
+  dpkg-deb --build --root-owner-group "${staging}" "${deb_path}"
+
+  _log_separator
+  _log_ok "DEB built successfully"
+  _log_info "Package: ${deb_path}"
+  _log_separator
+}
+
+main "$@"

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: build-rpm.sh
+# DESCRIPTION: Build a nixlper RPM package.
+#              Requires: rpmbuild (rpm-build package on RHEL/Fedora/Rocky)
+########################################################################################################################
+set -o nounset
+set -o errexit
+set -o pipefail
+
+readonly SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+_log_separator() { echo "====================================================================================="; }
+_log_info()  { echo "ℹ️  $1"; }
+_log_ok()    { echo "✅ $1"; }
+_log_error() { echo "❌ $1" >&2; }
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Version — strip leading 'v' from git tag so RPM Version: is plain numeric (e.g. 1.2.3 not v1.2.3)
+#-----------------------------------------------------------------------------------------------------------------------
+_get_version() {
+  local tag
+  tag=$(git describe --tags --exact-match HEAD 2>/dev/null | sed 's/^v//' || true)
+  if [[ -n "${tag}" ]]; then
+    echo "${tag}"
+  else
+    # Fallback to short SHA for dev builds
+    git log -n 1 --pretty=format:%h
+  fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Locate the tar produced by build.sh
+#-----------------------------------------------------------------------------------------------------------------------
+_get_tar_path() {
+  local -r version="$1"
+  local versioned="${SCRIPT_DIR}/build/distributions/nixlper-${version}.tar"
+  local unversioned="${SCRIPT_DIR}/build/distributions/nixlper.tar"
+  if [[ -f "${versioned}" ]]; then
+    echo "${versioned}"
+  elif [[ -f "${unversioned}" ]]; then
+    echo "${unversioned}"
+  else
+    _log_error "No tar found in build/distributions/ — run build.sh first"
+    return 1
+  fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Main
+#-----------------------------------------------------------------------------------------------------------------------
+main() {
+  _log_separator
+  _log_info "Build nixlper RPM"
+  _log_separator
+
+  # Check rpmbuild is available
+  if ! command -v rpmbuild &>/dev/null; then
+    _log_error "rpmbuild not found — install rpm-build package (dnf install rpm-build)"
+    exit 1
+  fi
+
+  # Resolve version
+  local -r version=$(_get_version)
+  local -r changelog_date=$(date "+%a %b %d %Y")
+  _log_info "Version: ${version}"
+
+  # Build the bash tar first
+  _log_info "Building nixlper tar..."
+  bash "${SCRIPT_DIR}/build.sh"
+  _log_ok "Tar built"
+
+  # Locate tar
+  local -r tar_path=$(_get_tar_path "${version}")
+  _log_info "Using tar: ${tar_path}"
+
+  # Set up rpmbuild tree
+  local -r rpmbuild_dir="${HOME}/rpmbuild"
+  mkdir -p "${rpmbuild_dir}"/{SOURCES,SPECS,BUILD,RPMS,SRPMS}
+
+  # Copy all sources
+  cp "${tar_path}" "${rpmbuild_dir}/SOURCES/nixlper-${version}.tar"
+  cp "${SCRIPT_DIR}/packaging/shared/nixlper.conf"          "${rpmbuild_dir}/SOURCES/nixlper.conf"
+  cp "${SCRIPT_DIR}/packaging/shared/nixlper-profile.d.sh"  "${rpmbuild_dir}/SOURCES/nixlper-profile.d.sh"
+  cp "${SCRIPT_DIR}/LICENSE"                                 "${rpmbuild_dir}/SOURCES/LICENSE"
+  cp "${SCRIPT_DIR}/packaging/rpm/nixlper.spec"              "${rpmbuild_dir}/SPECS/nixlper.spec"
+  _log_ok "Sources staged in ${rpmbuild_dir}/SOURCES/"
+
+  # Build binary RPM
+  _log_info "Running rpmbuild..."
+  rpmbuild -bb \
+    --define "nixlper_version ${version}" \
+    --define "nixlper_changelog_date ${changelog_date}" \
+    "${rpmbuild_dir}/SPECS/nixlper.spec"
+
+  _log_separator
+  _log_ok "RPM built successfully"
+  _log_info "Package location:"
+  find "${rpmbuild_dir}/RPMS" -name "nixlper-*.rpm" | sort
+  _log_separator
+}
+
+main "$@"

--- a/packaging/rpm/nixlper.spec
+++ b/packaging/rpm/nixlper.spec
@@ -1,0 +1,91 @@
+Name:           nixlper
+Version:        %{nixlper_version}
+Release:        1%{?dist}
+Summary:        Bash helper for keyboard-driven file and directory management
+License:        MIT
+BuildArch:      noarch
+URL:            https://github.com/Minhounet/nixlper
+
+# Source0: pre-built tar produced by build.sh
+Source0:        nixlper-%{nixlper_version}.tar
+# Source1: system-wide config (admin-editable, preserved on upgrade)
+Source1:        nixlper.conf
+# Source2: profile.d loader — one line, activates nixlper for all users at login
+Source2:        nixlper-profile.d.sh
+# Source3: upstream license
+Source3:        LICENSE
+
+Requires:       bash >= 4.0
+Recommends:     vim
+Recommends:     tree
+
+%description
+Nixlper is a keyboard-driven bash helper for Linux environments inspired
+by Total Commander. It provides directory bookmarks, navigation, file
+operations, process management, macros, clipboard support, and a command
+palette, all driven from the keyboard.
+
+Activation is automatic for all users via /etc/profile.d/nixlper.sh.
+System defaults are in /etc/nixlper/nixlper.conf (admin-editable, never
+overwritten on upgrade). Each user can override any setting in
+~/.config/nixlper/nixlper.conf. Per-user data (bookmarks, snapshots,
+custom scripts) is stored under ~/.local/share/nixlper/ and
+~/.config/nixlper/ and is never touched by the package manager.
+
+
+%prep
+# Nothing to prepare — nixlper.sh is a pre-built merged bash script from build.sh.
+
+
+%build
+# Nothing to compile — pure bash.
+
+
+%install
+install -dm 755 %{buildroot}%{_datadir}/nixlper
+install -dm 755 %{buildroot}%{_datadir}/nixlper/help
+install -dm 755 %{buildroot}%{_sysconfdir}/nixlper
+install -dm 755 %{buildroot}%{_sysconfdir}/profile.d
+
+# Unpack the built scripts and help files
+tar -xf %{SOURCE0} -C %{buildroot}%{_datadir}/nixlper
+chmod 644 %{buildroot}%{_datadir}/nixlper/nixlper.sh
+chmod 644 %{buildroot}%{_datadir}/nixlper/version
+chmod 644 %{buildroot}%{_datadir}/nixlper/help/*
+
+# System config — admin editable, preserved on upgrade via %%config(noreplace)
+install -m 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/nixlper/nixlper.conf
+
+# profile.d loader — not editable, replaced on upgrade
+install -m 644 %{SOURCE2} %{buildroot}%{_sysconfdir}/profile.d/nixlper.sh
+
+# License
+install -Dm 644 %{SOURCE3} %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
+
+
+%files
+%license %{_datadir}/licenses/%{name}/LICENSE
+%dir %{_datadir}/nixlper
+%dir %{_datadir}/nixlper/help
+%{_datadir}/nixlper/nixlper.sh
+%{_datadir}/nixlper/version
+%{_datadir}/nixlper/help/*
+%dir %{_sysconfdir}/nixlper
+%config(noreplace) %{_sysconfdir}/nixlper/nixlper.conf
+%{_sysconfdir}/profile.d/nixlper.sh
+
+
+%post
+# profile.d handles activation at next login — nothing to do here.
+# User data directories (~/.local/share/nixlper/, ~/.config/nixlper/) are
+# created automatically on first login by nixlper.sh itself.
+
+
+%preun
+# Intentionally empty — user data in ~/.local/share/nixlper/ and
+# ~/.config/nixlper/ is never removed by the package manager.
+
+
+%changelog
+* %{nixlper_changelog_date} Quang-Minh TRAN <qgmh.tran@gmail.com> - %{nixlper_version}-1
+- Initial RPM packaging

--- a/packaging/shared/nixlper-profile.d.sh
+++ b/packaging/shared/nixlper-profile.d.sh
@@ -1,0 +1,1 @@
+source /usr/share/nixlper/nixlper.sh

--- a/packaging/shared/nixlper.conf
+++ b/packaging/shared/nixlper.conf
@@ -1,0 +1,15 @@
+# nixlper system configuration
+# Managed by the package manager (RPM/DEB) — edit to set system-wide defaults.
+# All values use :- so any variable already set in ~/.bashrc (manual install) takes precedence.
+# Users can override any value in ~/.config/nixlper/nixlper.conf.
+
+export NIXLPER_INSTALL_DIR="${NIXLPER_INSTALL_DIR:-/usr/share/nixlper}"
+export NIXLPER_NAVIGATE_MODE="${NIXLPER_NAVIGATE_MODE:-tree}"
+export NIXLPER_EDITOR="${NIXLPER_EDITOR:-vim}"
+export NIXLPER_DISABLE_WELCOME_MESSAGE="${NIXLPER_DISABLE_WELCOME_MESSAGE:-false}"
+
+# Per-user paths — $HOME expands at login time for each user.
+export NIXLPER_BOOKMARKS_FILE="${NIXLPER_BOOKMARKS_FILE:-${HOME}/.local/share/nixlper/bookmarks}"
+export NIXLPER_LAST_MACRO_BINDING_FILE="${NIXLPER_LAST_MACRO_BINDING_FILE:-${HOME}/.local/share/nixlper/last_macro_binding}"
+export NIXLPER_SNAPSHOT_DIR="${NIXLPER_SNAPSHOT_DIR:-${HOME}/.local/share/nixlper/snapshots}"
+export NIXLPER_CUSTOM_DIR="${NIXLPER_CUSTOM_DIR:-${HOME}/.config/nixlper/custom}"

--- a/src/main/bash/functions_files_and_folders.sh
+++ b/src/main/bash/functions_files_and_folders.sh
@@ -52,7 +52,7 @@ function _snapshot_file() {
     return 1
   fi
   local -r absolute_filepath=$(pwd)/$1
-  local -r snapshot_dir=${NIXLPER_INSTALL_DIR}/snapshots
+  local -r snapshot_dir="${NIXLPER_SNAPSHOT_DIR:-${NIXLPER_INSTALL_DIR}/snapshots}"
   if [[ -f ${snapshot_dir}${absolute_filepath} ]]; then
     read -rp "File ${absolute_filepath} has already been saved, overwrite files? (default is y)" overwrite_file_answer
     overwrite_file_answer=${overwrite_file_answer:-y}
@@ -81,7 +81,7 @@ function _restore_file() {
       _i_restore_file_interactive
   else
     local -r absolute_filepath=$(pwd)/$1
-    local -r snapshot_dir=${NIXLPER_INSTALL_DIR}/snapshots
+    local -r snapshot_dir="${NIXLPER_SNAPSHOT_DIR:-${NIXLPER_INSTALL_DIR}/snapshots}"
     if [[ -f ${snapshot_dir}${absolute_filepath} ]]; then
       read -rp "Restore ${absolute_filepath} ? (default is y)" restore_file_answer
       restore_file_answer=${restore_file_answer:-y}
@@ -103,7 +103,7 @@ function _restore_file() {
 # _i_restore_file_interactive: restore file in interactive mode
 #-----------------------------------------------------------------------------------------------------------------------
 function _i_restore_file_interactive() {
-  local -r snapshot_dir=${NIXLPER_INSTALL_DIR}/snapshots
+  local -r snapshot_dir="${NIXLPER_SNAPSHOT_DIR:-${NIXLPER_INSTALL_DIR}/snapshots}"
   cd "${snapshot_dir}" || (_i_log_as_error "snapshots dir does not exist" && return 1)
   if [[ $(find . -type f | wc -l) -gt 0 ]]; then
 

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -22,11 +22,11 @@ function _i_init() {
 }
 
 function _i_test_prerequisites() {
-  if ! grep "export NIXLPER_INSTALL_DIR" ~/.bashrc > /dev/null 2>&1 ; then
+  if [[ -z "${NIXLPER_INSTALL_DIR:-}" ]]; then
     _i_log_as_error "NIXLPER_INSTALL_DIR is not defined, please run \"install\" command"
     return 1
   fi
-  if ! grep "export NIXLPER_BOOKMARKS_FILE" ~/.bashrc > /dev/null 2>&1 ; then
+  if [[ -z "${NIXLPER_BOOKMARKS_FILE:-}" ]]; then
     _i_log_as_error "NIXLPER_BOOKMARKS_FILE is not defined, please run \"install\" command"
     return 1
   fi
@@ -34,7 +34,7 @@ function _i_test_prerequisites() {
 
 # Custom scripts can be put in custom folder if specific things are needed
 function _i_load_custom_libraries() {
-  local -r custom_dir=${NIXLPER_INSTALL_DIR}/custom
+  local -r custom_dir="${NIXLPER_CUSTOM_DIR:-${NIXLPER_INSTALL_DIR}/custom}"
   if [[ -d "${custom_dir}" ]] ; then
     local -r nb_of_scripts=$(find "${custom_dir}" -type f | wc -l)
     if [[ ${nb_of_scripts} -gt 0 ]]; then
@@ -63,7 +63,7 @@ function _i_load_custom_libraries() {
 }
 
 function _i_create_snapshot_folder() {
-  local -r snapshot_dir=${NIXLPER_INSTALL_DIR}/snapshots
+  local -r snapshot_dir="${NIXLPER_SNAPSHOT_DIR:-${NIXLPER_INSTALL_DIR}/snapshots}"
   if [[ ! -d "${snapshot_dir}" ]] ; then
     echo "Snapshots directory does not exist, create it"
     mkdir -p "${snapshot_dir}"
@@ -77,6 +77,7 @@ function _i_create_snapshot_folder() {
 function _i_create_bookmarks_file_if_not_existing() {
   if [[ ! -f $NIXLPER_BOOKMARKS_FILE ]]; then
     echo "Bookmarks file does not exist, create ${NIXLPER_BOOKMARKS_FILE}"
+    mkdir -p "$(dirname "${NIXLPER_BOOKMARKS_FILE}")"
     touch "${NIXLPER_BOOKMARKS_FILE}"
     chmod 777 "${NIXLPER_BOOKMARKS_FILE}"
   fi
@@ -243,6 +244,8 @@ function _refresh_current_directory() {
 #***********************************************************************************************************************
 # ALIASES
 #***********************************************************************************************************************
+[[ "${NIXLPER_LOADED:-false}" == "true" ]] && return 0
+export NIXLPER_LOADED=true
 alias c=_mark_folder_as_current
 alias cdf=_change_directory_from_filepath
 alias cf=_mark_file_as_current

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -242,6 +242,16 @@ function _refresh_current_directory() {
 }
 
 #***********************************************************************************************************************
+# CONFIGURATION LOADING
+# 1. System config (/etc/nixlper/nixlper.conf) — managed by RPM/DEB, uses :- so already-set
+#    vars from ~/.bashrc (manual install) are not overridden.
+# 2. User config (~/.config/nixlper/nixlper.conf) — personal overrides, plain export wins
+#    over system defaults.
+#***********************************************************************************************************************
+[[ -f /etc/nixlper/nixlper.conf ]] && source /etc/nixlper/nixlper.conf
+[[ -f "${HOME}/.config/nixlper/nixlper.conf" ]] && source "${HOME}/.config/nixlper/nixlper.conf"
+
+#***********************************************************************************************************************
 # ALIASES
 #***********************************************************************************************************************
 [[ "${NIXLPER_LOADED:-false}" == "true" ]] && return 0


### PR DESCRIPTION
## Summary
This PR introduces RPM packaging for nixlper and refactors the installation system to support multiple distribution methods (manual tar, RPM, and planned DEB). The codebase now follows a configuration precedence chain that allows system-wide defaults (via RPM/DEB) to coexist with per-user overrides and manual installations.

## Key Changes

### New Build & Packaging Infrastructure
- **`build-rpm.sh`**: New RPM build script that calls `build.sh`, stages sources, and invokes `rpmbuild` to produce a noarch RPM package
- **`packaging/rpm/nixlper.spec`**: RPM spec file with proper handling of config files (`%config(noreplace)` for `/etc/nixlper/nixlper.conf`), profile.d activation, and intentionally empty `%post`/`%preun` hooks
- **`packaging/shared/nixlper.conf`**: System-wide configuration file using `:-` parameter expansion to preserve manual install settings
- **`packaging/shared/nixlper-profile.d.sh`**: Single-line profile.d loader that activates nixlper for all users at login without requiring `.bashrc` modifications

### Configuration Precedence Chain
- System defaults from `/etc/nixlper/nixlper.conf` (RPM/DEB managed, uses `:-` to avoid overriding existing vars)
- Per-user overrides from `~/.config/nixlper/nixlper.conf`
- Manual install vars set directly in `~/.bashrc`
- Fallback paths for `NIXLPER_SNAPSHOT_DIR` and `NIXLPER_CUSTOM_DIR` using `:-` in nixlper.sh

### Core Script Updates
- **`nixlper.sh`**: 
  - Added config loading for `/etc/nixlper/nixlper.conf` and `~/.config/nixlper/nixlper.conf`
  - Added `NIXLPER_LOADED` guard to prevent double initialization when both `.bashrc` and profile.d are active
  - Changed prerequisite checks from grepping `~/.bashrc` to checking if variables are set
  - Updated snapshot/custom directory resolution to use new environment variables with fallbacks
  - Fixed `_i_create_bookmarks_file_if_not_existing()` to create parent directories
- **`functions_files_and_folders.sh`**: Updated snapshot directory references to use `NIXLPER_SNAPSHOT_DIR` with fallback

### Documentation
- Updated `.claude/claude.md` with:
  - New meta section on keeping context current
  - Expanded build flow diagram showing both tar and RPM paths
  - Updated directory structure with new packaging files
  - Detailed environment variable precedence table
  - Comprehensive RPM packaging section with installation/upgrade/uninstall instructions
  - Planned DEB packaging notes
  - Updated build and installation instructions for all methods

## Implementation Details

**RPM Design Decisions:**
- `BuildArch: noarch` — pure bash, no compilation needed
- `/etc/profile.d/nixlper.sh` is NOT marked `%config` — it's always replaced on upgrade to ensure profile.d activation works correctly
- User data directories (`~/.local/share/nixlper/`, `~/.config/nixlper/`) are created on first login by nixlper.sh itself, never owned by the package
- Compatibility with manual tar installs via the double-load guard and fallback path resolution

**Installation Methods Now Supported:**
1. Manual tar: User extracts to chosen directory, runs `./nixlper.sh install` to update `~/.bashrc`
2. RPM: System-wide installation via `dnf install`, automatic activation via profile.d, admin-editable `/etc/nixlper/nixlper.conf`
3. DEB: Planned for next session, will share config files from `packaging/shared/`

https://claude.ai/code/session_01MqqkJkJxrEaA1TFci9pAQm