### PR TITLE
docs: add RPM and DEB installation sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,64 @@ Your .bashrc file will be updated and nixlper will be ready to be used for next 
 For an update just follow the same steps except for last command which will be:
 `./nixlper.sh update`
 
+### RPM install (RHEL / Fedora / Rocky Linux)
+
+Download the latest `.rpm` from the [GitHub Releases](https://github.com/Minhounet/nixlper/releases) page, then install it:
+
+```bash
+# With dnf (recommended — handles dependencies)
+sudo dnf install nixlper-*.rpm
+
+# Or with rpm directly
+sudo rpm -ivh nixlper-*.rpm
+```
+
+To upgrade an existing installation:
+
+```bash
+sudo dnf upgrade nixlper-*.rpm
+# or
+sudo rpm -Uvh nixlper-*.rpm
+```
+
+After installation, nixlper is automatically activated for all users via `/etc/profile.d/nixlper.sh` at next login.
+System-wide defaults live in `/etc/nixlper/nixlper.conf` (preserved on upgrade).
+Per-user overrides go in `~/.config/nixlper/nixlper.conf`.
+
+To remove:
+
+```bash
+sudo dnf remove nixlper
+# or
+sudo rpm -e nixlper
+```
+
+### DEB install (Debian / Ubuntu)
+
+Download the latest `.deb` from the [GitHub Releases](https://github.com/Minhounet/nixlper/releases) page, then install it:
+
+```bash
+# With apt (recommended — handles dependencies)
+sudo apt install ./nixlper_*_all.deb
+
+# Or with dpkg directly
+sudo dpkg -i nixlper_*_all.deb
+```
+
+To upgrade, simply re-run the install command with the new `.deb` file.
+
+After installation, nixlper is automatically activated for all users via `/etc/profile.d/nixlper.sh` at next login.
+System-wide defaults live in `/etc/nixlper/nixlper.conf` (preserved on upgrade).
+Per-user overrides go in `~/.config/nixlper/nixlper.conf`.
+
+To remove:
+
+```bash
+sudo apt remove nixlper
+# or
+sudo dpkg -r nixlper
+```
+
 ### Uninstall
 
 This is pretty simple, just perform the command below from the install path:

--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ chmod +x install.sh
 sudo ./install.sh --system
 ```
 
-To uninstall a system-wide install:
-
-```bash
-sudo /opt/nixlper/nixlper.sh uninstall-system
-```
-
 ### Manual install
 
 This method also activates nixlper **for the current user only** by adding a block to `~/.bashrc`.
@@ -111,6 +105,21 @@ Your .bashrc file will be updated and nixlper will be ready to be used for next 
 
 For an update just follow the same steps except for last command which will be:
 `./nixlper.sh update`
+
+### Manual uninstall
+
+Run the command below from the install directory:
+
+```bash
+cd /opt/nixlper
+./nixlper.sh uninstall
+```
+
+For a system-wide install:
+
+```bash
+sudo /opt/nixlper/nixlper.sh uninstall-system
+```
 
 ### RPM install (RHEL / Fedora / Rocky Linux)
 
@@ -169,13 +178,6 @@ sudo apt remove nixlper
 # or
 sudo dpkg -r nixlper
 ```
-
-### Uninstall
-
-This is pretty simple, just perform the command below from the install path:
-`./nixlper uninstall`
-
-"Sorry that you uninstall it! :("
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ You will have in build/distributions the nixlper-<version>.tar archive.
 
 ## Installation
 
+> **Scope overview**
+> - **Quick install / Manual install** — current user only: configures `~/.bashrc`.
+> - **RPM / DEB** — all users: activates nixlper system-wide via `/etc/profile.d/nixlper.sh`.
+
 ### Quick install (recommended)
 
 The easiest way to install or update Nixlper is to use the install script.
 It automatically detects whether Nixlper is already installed and performs a first install or an update accordingly.
+This method activates nixlper **for the current user only** by adding a block to `~/.bashrc`.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/master/install.sh | bash
@@ -59,6 +64,8 @@ The script will:
 - **Update**: download the new version into the existing install directory, preserving your custom scripts
 
 ### Manual install
+
+This method also activates nixlper **for the current user only** by adding a block to `~/.bashrc`.
 
 Perform the commands below for the first install:
 - Put the archive on any server in the folder you want to install it (for instance **/opt/nixlper**)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ You will have in build/distributions the nixlper-<version>.tar archive.
 
 > **Scope overview**
 > - **Quick install / Manual install** — current user only: configures `~/.bashrc`.
-> - **RPM / DEB** — all users: activates nixlper system-wide via `/etc/profile.d/nixlper.sh`.
+> - **Quick install `--system` / Manual `install-system`** — all users: writes `/etc/profile.d/nixlper.sh` (requires `sudo`).
+> - **RPM / DEB** — all users: same mechanism, managed by the package manager.
 
 ### Quick install (recommended)
 
@@ -62,6 +63,29 @@ The script will:
 - Detect if Nixlper is already installed
 - **First install**: ask for an install directory (default `/opt/nixlper`), download, extract, and configure `.bashrc`
 - **Update**: download the new version into the existing install directory, preserving your custom scripts
+
+### Quick install — system-wide (all users)
+
+To install for all users, pass `--system`. This requires running as root and writes
+`/etc/profile.d/nixlper.sh` and `/etc/nixlper/nixlper.conf` instead of touching `~/.bashrc`.
+
+```bash
+sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/master/install.sh)" -- --system
+```
+
+Or download and run manually:
+
+```bash
+curl -fsSL -o install.sh https://raw.githubusercontent.com/Minhounet/nixlper/master/install.sh
+chmod +x install.sh
+sudo ./install.sh --system
+```
+
+To uninstall a system-wide install:
+
+```bash
+sudo /opt/nixlper/nixlper.sh uninstall-system
+```
 
 ### Manual install
 

--- a/install.sh
+++ b/install.sh
@@ -87,8 +87,13 @@ _is_nixlper_installed() {
     return 0
   fi
 
-  # Check 2: .bashrc contains the nixlper block
+  # Check 2: .bashrc contains the nixlper block (per-user install)
   if grep -q "nixlper start" ~/.bashrc 2>/dev/null; then
+    return 0
+  fi
+
+  # Check 3: system-wide install markers
+  if [[ -f /etc/profile.d/nixlper.sh ]] || [[ -f /etc/nixlper/nixlper.conf ]]; then
     return 0
   fi
 
@@ -102,7 +107,7 @@ _get_current_install_dir() {
     return
   fi
 
-  # Fall back to parsing .bashrc
+  # Fall back to parsing .bashrc (per-user install)
   local dir
   dir=$(grep 'export NIXLPER_INSTALL_DIR=' ~/.bashrc 2>/dev/null \
         | tail -1 \
@@ -111,6 +116,15 @@ _get_current_install_dir() {
   if [[ -n "${dir}" ]] && [[ -d "${dir}" ]]; then
     echo "${dir}"
     return
+  fi
+
+  # Fall back to system conf
+  if [[ -f /etc/nixlper/nixlper.conf ]]; then
+    dir=$(bash -c 'source /etc/nixlper/nixlper.conf 2>/dev/null && echo "${NIXLPER_INSTALL_DIR:-}"')
+    if [[ -n "${dir}" ]] && [[ -d "${dir}" ]]; then
+      echo "${dir}"
+      return
+    fi
   fi
 
   echo ""
@@ -122,8 +136,13 @@ _get_current_install_dir() {
 _first_install() {
   local -r install_dir="$1"
   local -r archive_path="$2"
+  local -r system_mode="${3:-false}"
 
-  _log_info "Performing first install into ${install_dir}"
+  if [[ "${system_mode}" == "true" ]]; then
+    _log_info "Performing system-wide install into ${install_dir}"
+  else
+    _log_info "Performing first install into ${install_dir}"
+  fi
 
   mkdir -p "${install_dir}"
   tar -xf "${archive_path}" -C "${install_dir}"
@@ -132,18 +151,27 @@ _first_install() {
   chmod +x "${install_dir}/nixlper.sh"
 
   cd "${install_dir}"
-  ./nixlper.sh install
+  if [[ "${system_mode}" == "true" ]]; then
+    ./nixlper.sh install-system
+  else
+    ./nixlper.sh install
+  fi
 
   _log_ok "Nixlper installed successfully in ${install_dir}"
   echo ""
-  _log_info "Please run one of the following to activate nixlper:"
-  echo "    source ~/.bashrc"
-  echo "    (or log out and log back in)"
+  if [[ "${system_mode}" == "true" ]]; then
+    _log_info "Nixlper will be activated for all users at next login."
+  else
+    _log_info "Please run one of the following to activate nixlper:"
+    echo "    source ~/.bashrc"
+    echo "    (or log out and log back in)"
+  fi
 }
 
 _update_install() {
   local -r install_dir="$1"
   local -r archive_path="$2"
+  local -r system_mode="${3:-false}"
 
   _log_info "Updating existing installation in ${install_dir}"
 
@@ -167,23 +195,45 @@ _update_install() {
   chmod +x "${install_dir}/nixlper.sh"
 
   cd "${install_dir}"
-  ./nixlper.sh update
+  if [[ "${system_mode}" == "true" ]]; then
+    ./nixlper.sh update-system
+  else
+    ./nixlper.sh update
+  fi
 
   _log_ok "Nixlper updated successfully"
   echo ""
-  _log_info "Please run one of the following to activate the new version:"
-  echo "    source ~/.bashrc"
-  echo "    (or log out and log back in)"
+  if [[ "${system_mode}" == "true" ]]; then
+    _log_info "All users will get the new version at next login."
+  else
+    _log_info "Please run one of the following to activate the new version:"
+    echo "    source ~/.bashrc"
+    echo "    (or log out and log back in)"
+  fi
 }
 
 #***********************************************************************************************************************
 # Main
 #***********************************************************************************************************************
 main() {
+  local system_mode=false
+  if [[ "${1:-}" == "--system" ]]; then
+    system_mode=true
+  fi
+
   _log_separator
-  echo "  Nixlper Installer"
+  if [[ "${system_mode}" == "true" ]]; then
+    echo "  Nixlper Installer (system-wide)"
+  else
+    echo "  Nixlper Installer"
+  fi
   _log_separator
   echo ""
+
+  if [[ "${system_mode}" == "true" ]] && [[ ${EUID} -ne 0 ]]; then
+    _log_error "System-wide install requires root. Run: sudo $0 --system"
+    exit 1
+  fi
 
   _check_prerequisites
 
@@ -210,7 +260,7 @@ main() {
     if [[ "${answer}" =~ ^[Yy]$ ]]; then
       local archive_path
       archive_path=$(_download_release "${tag}" "${install_dir}")
-      _update_install "${install_dir}" "${archive_path}"
+      _update_install "${install_dir}" "${archive_path}" "${system_mode}"
     else
       _log_info "Update cancelled"
     fi
@@ -229,7 +279,7 @@ main() {
     if [[ "${answer}" =~ ^[Yy]$ ]]; then
       local archive_path
       archive_path=$(_download_release "${tag}" "/tmp")
-      _first_install "${install_dir}" "/tmp/$(basename "${archive_path}")"
+      _first_install "${install_dir}" "/tmp/$(basename "${archive_path}")" "${system_mode}"
     else
       _log_info "Installation cancelled"
     fi

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -136,6 +136,75 @@ function _i_uninstall() {
   echo "---------------------------------------------------------------------------------------------------------------"
 }
 
+function _i_install_system() {
+  echo "---------------------------------------------------------------------------------------------------------------"
+  echo "Install Nixlper system-wide"
+  if [[ ${EUID} -ne 0 ]]; then
+    _i_log_as_error "System install requires root. Run: sudo ./install.sh --system"
+    return 1
+  fi
+
+  local install_dir
+  if [[ -z "${NIXLPER_INSTALL_DIR:-}" ]]; then
+    cd "$(dirname "$0")" || return 1
+    install_dir="$(pwd)"
+  else
+    install_dir="${NIXLPER_INSTALL_DIR}"
+  fi
+
+  mkdir -p /etc/nixlper
+  cat > /etc/nixlper/nixlper.conf <<EOF
+# nixlper system configuration — edit to set system-wide defaults.
+# Users can override any value in ~/.config/nixlper/nixlper.conf.
+
+export NIXLPER_INSTALL_DIR="\${NIXLPER_INSTALL_DIR:-${install_dir}}"
+export NIXLPER_NAVIGATE_MODE="\${NIXLPER_NAVIGATE_MODE:-tree}"
+export NIXLPER_EDITOR="\${NIXLPER_EDITOR:-vim}"
+export NIXLPER_DISABLE_WELCOME_MESSAGE="\${NIXLPER_DISABLE_WELCOME_MESSAGE:-false}"
+
+# Per-user paths — \$HOME expands at login time for each user.
+export NIXLPER_BOOKMARKS_FILE="\${NIXLPER_BOOKMARKS_FILE:-\${HOME}/.local/share/nixlper/bookmarks}"
+export NIXLPER_LAST_MACRO_BINDING_FILE="\${NIXLPER_LAST_MACRO_BINDING_FILE:-\${HOME}/.local/share/nixlper/last_macro_binding}"
+export NIXLPER_SNAPSHOT_DIR="\${NIXLPER_SNAPSHOT_DIR:-\${HOME}/.local/share/nixlper/snapshots}"
+export NIXLPER_CUSTOM_DIR="\${NIXLPER_CUSTOM_DIR:-\${HOME}/.config/nixlper/custom}"
+EOF
+  chmod 644 /etc/nixlper/nixlper.conf
+
+  printf 'source %s/nixlper.sh\n' "${install_dir}" > /etc/profile.d/nixlper.sh
+  chmod 644 /etc/profile.d/nixlper.sh
+
+  echo "-> DONE (Install Nixlper system-wide)"
+  echo "Nixlper will be activated for all users at next login."
+  echo "---------------------------------------------------------------------------------------------------------------"
+}
+
+function _i_update_system() {
+  echo "---------------------------------------------------------------------------------------------------------------"
+  echo "Update Nixlper system-wide"
+  if [[ ${EUID} -ne 0 ]]; then
+    _i_log_as_error "System update requires root. Run: sudo ./install.sh --system"
+    return 1
+  fi
+  # The new nixlper.sh is already in place (extracted by install.sh).
+  # /etc/profile.d/nixlper.sh and /etc/nixlper/nixlper.conf are left untouched.
+  echo "-> DONE (Update Nixlper system-wide)"
+  echo "---------------------------------------------------------------------------------------------------------------"
+}
+
+function _i_uninstall_system() {
+  echo "---------------------------------------------------------------------------------------------------------------"
+  echo "Uninstall Nixlper system-wide"
+  if [[ ${EUID} -ne 0 ]]; then
+    _i_log_as_error "System uninstall requires root. Run: sudo ./nixlper.sh uninstall-system"
+    return 1
+  fi
+  rm -f /etc/profile.d/nixlper.sh
+  rm -f /etc/nixlper/nixlper.conf
+  rmdir /etc/nixlper 2>/dev/null || true
+  echo "-> DONE (Uninstall Nixlper system-wide)"
+  echo "---------------------------------------------------------------------------------------------------------------"
+}
+
 function _i_set_bashrc_config() {
   echo "  Update .bashrc with nixlper"
   echo "" >> ~/.bashrc
@@ -300,11 +369,23 @@ function main() {
     uninstall)
       _i_uninstall
       ;;
+    install-system)
+      _i_install_system
+      ;;
+    update-system)
+      _i_update_system
+      ;;
+    uninstall-system)
+      _i_uninstall_system
+      ;;
     *)
       echo "command ${command} is unknown, use one the following ones:
-            install: to install NIXLPER
-            update: to update NIXLPER with higher version
-            uninstall: to uninstall NIXLPER, installation will be removed"
+            install: to install NIXLPER (current user)
+            update: to update NIXLPER (current user)
+            uninstall: to uninstall NIXLPER (current user)
+            install-system: to install NIXLPER for all users (requires root)
+            update-system: to update NIXLPER for all users (requires root)
+            uninstall-system: to uninstall NIXLPER for all users (requires root)"
     esac
   fi
 }


### PR DESCRIPTION
Documents how to install, upgrade, and remove nixlper using the
pre-built .rpm (RHEL/Fedora/Rocky) and .deb (Debian/Ubuntu) packages
from GitHub Releases. Covers both the recommended package-manager
commands (dnf/apt) and the lower-level alternatives (rpm/dpkg).
Also notes the profile.d activation and config file locations that
apply to both package formats.

https://claude.ai/code/session_016kKVFTAU8xZ3kc9WiTLVvf