### PR TITLE
🐛fix|Fix v-prefix mismatch causing tar not found in RPM and DEB builds.

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -61,8 +61,8 @@ main() {
   bash "${SCRIPT_DIR}/build.sh"
   _log_ok "Tar built"
 
-  # build.sh names the tar after the git tag (or bare project name), not the DEB version
-  local -r git_tag=$(git describe --tags --exact-match HEAD 2>/dev/null | sed 's/^v//' || true)
+  # build.sh names the tar with the unmodified git tag (e.g. nixlper-v1.0.0.tar)
+  local -r git_tag=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
   local -r tar_path=$(_get_tar_path "${git_tag}")
   _log_info "Using tar: ${tar_path}"
 

--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -18,10 +18,11 @@ _log_error() { echo "❌ $1" >&2; }
 #-----------------------------------------------------------------------------------------------------------------------
 # Version — strip leading 'v' from git tag so RPM Version: is plain numeric (e.g. 1.2.3 not v1.2.3)
 #-----------------------------------------------------------------------------------------------------------------------
-# Returns the raw tag (strip leading v only) — used to locate the tar produced by build.sh.
+# Returns the exact git tag (no transformation) — used to locate the tar produced by build.sh,
+# which names the archive with the unmodified tag (e.g. nixlper-v1.0.0.tar).
 _get_raw_version() {
   local tag
-  tag=$(git describe --tags --exact-match HEAD 2>/dev/null | sed 's/^v//' || true)
+  tag=$(git describe --tags --exact-match HEAD 2>/dev/null || true)
   if [[ -n "${tag}" ]]; then
     echo "${tag}"
   else
@@ -29,9 +30,10 @@ _get_raw_version() {
   fi
 }
 
-# Returns an RPM-safe version: hyphens replaced with underscores (RPM forbids '-' in Version).
+# Returns an RPM-safe version: leading 'v' stripped, hyphens replaced with underscores
+# (RPM forbids '-' in Version).
 _get_version() {
-  _get_raw_version | sed 's/-/_/g'
+  _get_raw_version | sed 's/^v//' | sed 's/-/_/g'
 }
 
 #-----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
build.sh names archives with the full git tag (e.g. nixlper-v1.0.0.tar),
but build-rpm.sh and build-deb.sh were stripping the leading 'v' before
the tar lookup, so they searched for nixlper-1.0.0.tar and failed.
Fix: preserve the full tag in _get_raw_version() / git_tag; strip 'v'
only in _get_version() for the RPM/DEB version fields.

https://claude.ai/code/session_0194tDDhxf8tRzRMJ6vi43e3