### PR TITLE
📝docs|Resolve ISSUE-4: Add `olf` command to in-shell help.

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -74,18 +74,6 @@ documented arguments — they are not related to the `find_action` (CTRL+X+A) pa
 Per CLAUDE.md, every command in `README.md → ## Features → ### <Category>` must also appear in
 the matching `src/main/help/help_<category>` file, and vice versa.
 
-### ISSUE-4 — `olf` missing from in-shell help
-
-- **Impact:** 🟡 Minor — documentation only. Feature works; it is just undiscoverable via
-  CTRL+X+H help.
-- **Files:** documented in `README.md` (Files & Folders) but absent from
-  `src/main/help/help_files_folders`.
-- **Symptom:** `olf` (open latest modified file) shows in the README but not in CTRL+X+H help.
-- **Suggested fix:** Add an `olf` line to `help_files_folders` (e.g. under a new "Open" section):
-  `olf : open the most recently modified file in the current repository`.
-
----
-
 ## Notes
 
 - The command palette's inability to pass arguments to argument-taking commands is **not** a bug

--- a/src/main/help/help_files_folders
+++ b/src/main/help/help_files_folders
@@ -23,6 +23,9 @@ Safe delete
 [CTRL + X then E] display a safe rm command such as `rm -i -rf /tmp/qmt/anyfolder && cd..` to quickly delete current folder and to avoid `rm -rf *` in your bash history.
 [CTRL + X then R] display a safe rm command such as `rm -i -rf /tmp/qmt/anyfolder/* ` to quickly delete current folder contents and to avoid `rm -rf *` in your bash history.
 ------------------------------------------------------------------------------------------------------------------------
+Open
+olf : open the most recently modified file in the current directory
+------------------------------------------------------------------------------------------------------------------------
 Save/Restore
 sn FILEPATH : save file in the snapshot area
 re [FILEPATH] : restore a file, if there is no parameters, a list of choices will be displayed for interactive restore


### PR DESCRIPTION
## Summary
Resolves ISSUE-4 by adding the `olf` (open latest modified file) command to the in-shell help system, making it discoverable via CTRL+X+H help alongside its README documentation.

## Changes
- **`src/main/help/help_files_folders`**: Added new "Open" section with `olf` command description
- **`KNOWN_ISSUES.md`**: Removed ISSUE-4 entry (now fixed)

## Details
The `olf` command was documented in README.md but missing from the corresponding help file, violating the project convention that every documented command must appear in both places. Added a concise help entry under a new "Open" section to maintain consistency and improve discoverability through the in-shell help system.

https://claude.ai/code/session_01DYhrorHJN6M96L9jjsRtq1