### PR TITLE
🐛fix|Fix sn false-success when given an absolute path.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,12 @@ Source: `https://raw.githubusercontent.com/carloscuesta/gitmoji/master/packages/
 2. Test installation
 3. Verify keyboard bindings work
 
+### Testing requirement (bugs and features)
+After implementing a bug fix or a new feature, **always test it** before committing:
+- Source the affected module(s) in a subshell and exercise the changed function directly.
+- Cover at minimum: the fixed/new case, a regression case (existing behaviour unchanged), and an error/edge case.
+- If testing is genuinely impossible in the current environment (missing runtime dependency, interactive terminal required, etc.), **explicitly warn the user** before committing — never silently skip testing.
+
 ---
 
 ## Adding New Features

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -21,30 +21,6 @@ and verified. These are intended to be addressed in dedicated follow-up sessions
 These bugs occur when the command is invoked **directly** on the command line with its
 documented arguments — they are not related to the `find_action` (CTRL+X+A) palette.
 
-### ISSUE-1 — `fan` / `fag` silently miss paths containing spaces
-
-- **Impact:** 🟠 Important — the command appears to work (exit 0) but silently omits matches,
-  so the user can wrongly conclude "no such file". Only triggers when a path contains a space.
-- **Commands:** `fan` (`_find_and_navigate`), `fag` (`_grep_and_navigate`)
-- **Files:** `src/main/bash/functions_navigation.sh:185` (`for i in ${find_results}`)
-  and `src/main/bash/functions_navigation.sh:237` (`for i in ${grep_results}`)
-- **Symptom:** A file whose path contains a space is never listed, and no `v#`/`cdf#`/`n#`/`d#`
-  alias is created for it. The command exits 0 and appears to "find nothing".
-- **Reproduction:**
-  ```bash
-  mkdir -p "my dir" && echo x > "my dir/space file.txt"
-  fan space      # prints ".." / ".." with zero matches
-  ```
-- **Root cause:** The unquoted `for i in ${find_results}` / `${grep_results}` word-splits each
-  path on whitespace (IFS), so a path like `./my dir/space file.txt` is broken into separate
-  words and fails the `[[ -f $i ]]` / `[[ -d $i ]]` tests.
-- **Suggested fix:** Iterate with a NUL/newline-safe loop, e.g.
-  `find . -iname "*${pattern}*" -print0 | while IFS= read -r -d '' i; do ...`.
-  Note `fag` already sets `IFS=$'\n'` for its loop but `fan` does not; align both and make them
-  space-safe.
-
----
-
 ## Documentation drift (dual-location rule)
 
 Per CLAUDE.md, every command in `README.md → ## Features → ### <Category>` must also appear in

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -43,30 +43,6 @@ documented arguments — they are not related to the `find_action` (CTRL+X+A) pa
   Note `fag` already sets `IFS=$'\n'` for its loop but `fan` does not; align both and make them
   space-safe.
 
-### ISSUE-2 — `sn` reports false success on an absolute path
-
-- **Impact:** 🟠 Important (severe when triggered) — prints "has been saved" and returns 0 while
-  nothing was copied. A user who trusts that message and later edits/deletes the original can
-  lose data with no real warning. Only triggers when `sn` is given an absolute path; relative
-  filenames work correctly.
-- **Command:** `sn` (`_snapshot_file`)
-- **File:** `src/main/bash/functions_files_and_folders.sh:54`
-  (`local -r absolute_filepath=$(pwd)/$1`) and the missing `cp` exit-code check at lines 61/68.
-- **Symptom:** `sn /abs/path/file` blindly prepends `$(pwd)/`, producing a bogus path like
-  `/cwd//abs/path/file`. The underlying `cp` fails (`cannot stat …`) but the function still
-  prints `-> File … has been saved` and returns exit 0 — a false success.
-- **Reproduction:**
-  ```bash
-  echo y > /tmp/abs_sample.txt
-  sn /tmp/abs_sample.txt
-  # -> cp: cannot stat '/cwd//tmp/abs_sample.txt'
-  # -> INFO  -> File ... has been saved   (WRONG: nothing was saved, exit 0)
-  ```
-- **Root cause:** (a) Absolute paths are not detected before prepending `$(pwd)/`;
-  (b) the `cp` result is never checked before logging success.
-- **Suggested fix:** Detect `"$1" == /*` and use it as-is (mirror the pattern already used in
-  `_mark_file_as_current`); check `cp`'s exit status before logging "has been saved".
-
 ---
 
 ## Documentation drift (dual-location rule)

--- a/src/main/bash/functions_files_and_folders.sh
+++ b/src/main/bash/functions_files_and_folders.sh
@@ -53,22 +53,35 @@ function _snapshot_file() {
     echo "ERROR: missing filename"
     return 1
   fi
-  local -r absolute_filepath=$(pwd)/$1
+  local absolute_filepath
+  if [[ "$1" == /* ]]; then
+    absolute_filepath=$1
+  else
+    absolute_filepath=$(pwd)/$1
+  fi
   local -r snapshot_dir="${NIXLPER_SNAPSHOT_DIR:-${NIXLPER_INSTALL_DIR}/snapshots}"
   if [[ -f ${snapshot_dir}${absolute_filepath} ]]; then
     read -rp "File ${absolute_filepath} has already been saved, overwrite files? (default is y)" overwrite_file_answer
     overwrite_file_answer=${overwrite_file_answer:-y}
     if [[ ${overwrite_file_answer} == "y" ]]; then
       rm -rf "${snapshot_dir}${absolute_filepath}"
-      cp "${absolute_filepath}" "${snapshot_dir}${absolute_filepath}"
-      _i_log_as_info "-> File ${absolute_filepath} has been saved"
+      if cp "${absolute_filepath}" "${snapshot_dir}${absolute_filepath}"; then
+        _i_log_as_info "-> File ${absolute_filepath} has been saved"
+      else
+        _i_log_as_error "-> File ${absolute_filepath} could not be saved"
+        return 1
+      fi
     else
       _i_log_as_info "-> Action is aborted"
     fi
   else
     mkdir -p "$(dirname "${snapshot_dir}${absolute_filepath}")"
-    cp "${absolute_filepath}" "${snapshot_dir}${absolute_filepath}"
-    _i_log_as_info "-> File ${absolute_filepath} has been saved"
+    if cp "${absolute_filepath}" "${snapshot_dir}${absolute_filepath}"; then
+      _i_log_as_info "-> File ${absolute_filepath} has been saved"
+    else
+      _i_log_as_error "-> File ${absolute_filepath} could not be saved"
+      return 1
+    fi
   fi
 }
 #-----------------------------------------------------------------------------------------------------------------------

--- a/src/main/bash/functions_navigation.sh
+++ b/src/main/bash/functions_navigation.sh
@@ -183,6 +183,7 @@ function _find_and_navigate() {
       local path_depth
       local tree_chars
       echo ".."
+      IFS=$'\n'
       for i in ${find_results}; do
         tree_chars="├──"
         path_depth=$(echo "$i" | grep -o "/" | wc -l)
@@ -204,6 +205,7 @@ function _find_and_navigate() {
         fi
         ((item_increment++))
       done
+      unset IFS
       echo ".."
     else
       echo "No match"


### PR DESCRIPTION
Detect absolute paths before prepending \$(pwd)/; check cp exit status
before logging "has been saved" so failures are reported correctly.