### PR TITLE
✨feat|Add update detection with stable/edge channels and offline guard.

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,54 @@
+name: Claude Code
+
+# Two behaviors:
+#   - auto-review : reviews every PR automatically when it is opened or updated.
+#   - claude      : responds to @claude mentions in issue / PR / review comments.
+#
+# Prerequisites (one-time, by a repo admin):
+#   1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
+#      (or run /install-github-app from a Claude Code session).
+#   2. Add the ANTHROPIC_API_KEY secret under
+#      Settings → Secrets and variables → Actions.
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  # Automatic review on every (non-fork) PR open/update.
+  auto-review:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    concurrency:
+      group: claude-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-opus-4-8"
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+
+  # Respond to @claude mentions in comments.
+  claude:
+    if: >-
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--model claude-opus-4-8"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -4,8 +4,16 @@ name: Claude Code
 #   - auto-review : reviews every PR automatically when it is opened or updated.
 #   - claude      : responds to @claude mentions in issue / PR / review comments.
 #
+# Security notes:
+#   - The action only acts for users with write access (strangers commenting @claude
+#     are rejected), and never auto-creates PRs.
+#   - The action is pinned to a commit SHA (v1) to prevent a retagged/compromised action
+#     from running. Update the SHA deliberately when bumping versions.
+#   - Permissions are least-privilege per job: the review job gets no write access to repo
+#     contents (it only posts a review), the mention job may push fixes so it gets more.
+#
 # Prerequisites (one-time, by a repo admin):
-#   1. Install the Claude GitHub App on this repo: https://github.com/apps/claude
+#   1. Install the Claude GitHub App: https://github.com/apps/claude
 #      (or run /install-github-app from a Claude Code session).
 #   2. Add the ANTHROPIC_API_KEY secret under
 #      Settings → Secrets and variables → Actions.
@@ -17,11 +25,9 @@ on:
   pull_request_review_comment:
     types: [created]
 
+# Default to read-only; each job widens only what it needs.
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
-  id-token: write   # required: the action mints its GitHub token via OIDC
+  contents: read
 
 jobs:
   # Automatic review on every (non-fork) PR open/update.
@@ -30,11 +36,15 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read          # read the diff; no push needed for a review
+      pull-requests: write    # post the review
+      id-token: write         # OIDC token for the action
     concurrency:
       group: claude-review-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@d44caa1f5268e7643c11e317db4c2ad1e5ea3211 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-6"
@@ -48,8 +58,13 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: write         # may push fixes when asked
+      pull-requests: write
+      issues: write
+      id-token: write
     steps:
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@d44caa1f5268e7643c11e317db4c2ad1e5ea3211 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: "--model claude-sonnet-4-6"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  id-token: write   # required: the action mints its GitHub token via OIDC
 
 jobs:
   # Automatic review on every (non-fork) PR open/update.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-opus-4-8"
+          claude_args: "--model claude-sonnet-4-6"
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
@@ -52,4 +52,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: "--model claude-opus-4-8"
+          claude_args: "--model claude-sonnet-4-6"

--- a/.github/workflows/create_release_on_tag.yml
+++ b/.github/workflows/create_release_on_tag.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+      # The rolling "edge" tag is managed by publish_edge_on_push.yml — never treat it as a release.
+      - "!edge"
 
 jobs:
   create-release:

--- a/.github/workflows/publish_edge_on_push.yml
+++ b/.github/workflows/publish_edge_on_push.yml
@@ -1,0 +1,51 @@
+name: Publish edge build on push
+
+# Rolling "edge" channel: every push to main rebuilds the tar and overwrites a single
+# pre-release tagged `edge`, so edge-channel users always pull the latest commit from a
+# stable URL (releases/download/edge/nixlper-edge.tar). Marked prerelease so it never
+# appears as the stable "latest" release.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: edge-release
+  cancel-in-progress: true
+
+jobs:
+  publish-edge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y dos2unix
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build tar archive
+        run: |
+          chmod +x ./build.sh
+          ./build.sh
+
+      - name: Stage edge artifact
+        run: |
+          mkdir -p edge-dist
+          cp build/distributions/nixlper.tar edge-dist/nixlper-edge.tar
+
+      - name: Refresh edge pre-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Drop the previous edge release and its tag so we can re-point it at the new commit.
+          gh release delete edge --yes --cleanup-tag || true
+          gh release create edge edge-dist/nixlper-edge.tar \
+            --title "Edge (latest commit)" \
+            --notes "Rolling build of the latest commit on main (${{ github.sha }}). Auto-generated and overwritten on every push." \
+            --prerelease \
+            --target "${{ github.sha }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Syntax-check all bash sources
+        run: |
+          status=0
+          for f in src/main/bash/*.sh src/test/bash/*.sh install.sh build.sh build-rpm.sh build-deb.sh; do
+            [[ -f "$f" ]] || continue
+            if bash -n "$f"; then
+              echo "ok   $f"
+            else
+              echo "FAIL $f"
+              status=1
+            fi
+          done
+          exit $status
+
+      - name: Run update-detection unit tests
+        run: bash src/test/bash/test_functions_update.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Update detection with channels** (`NIXLPER_UPDATE_CHANNEL`): `stable` tracks tagged
+  releases and suggests an update when a newer tag exists; `edge` tracks the latest commit
+  via a rolling pre-release; `off` disables checks entirely.
+- On-demand update check: `nu` / `CTRL+X+W`. An automatic, throttled check also runs at shell
+  start (`NIXLPER_UPDATE_CHECK_INTERVAL`, default 24h).
+- Offline-safe: a fast reachability probe (`NIXLPER_UPDATE_TIMEOUT`) gates all network access,
+  so checks are skipped silently when the internet is unreachable.
+- Opt-in auto-update (`NIXLPER_UPDATE_AUTO`, default off).
+- `install.sh` gains `--channel stable|edge` and `--yes` (non-interactive), plus an internet
+  reachability check that aborts cleanly when offline.
+- CI publishes a rolling `edge` pre-release (`nixlper-edge.tar`) on every push to `main`.
+
+### Changed
+- The build now records the full commit SHA (`COMMIT:`) in the version file for edge comparison.
+
+---
+
 ## [2.0.1] - 2026-06-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,9 +377,28 @@ All variables follow a precedence chain — later sources override earlier ones:
 | `NIXLPER_EDITOR` | `vim` | `vim` |
 | `NIXLPER_DISABLE_WELCOME_MESSAGE` | `false` | `false` |
 | `NIXLPER_DISABLE_TIPS` | `false` | `false` |
+| `NIXLPER_UPDATE_CHANNEL` | `stable` | `stable` |
+| `NIXLPER_UPDATE_CHECK` | `true` | `true` |
+| `NIXLPER_UPDATE_AUTO` | `false` | `false` |
+| `NIXLPER_UPDATE_CHECK_INTERVAL` | `86400` | `86400` |
+| `NIXLPER_UPDATE_TIMEOUT` | `2` | `2` |
+| `NIXLPER_UPDATE_CACHE_FILE` | `$NIXLPER_INSTALL_DIR/.nixlper_update_check` | `~/.local/share/nixlper/update_check` |
 
 `NIXLPER_SNAPSHOT_DIR` and `NIXLPER_CUSTOM_DIR` are resolved inside nixlper.sh with `:-` fallbacks
 to `$NIXLPER_INSTALL_DIR/snapshots` and `$NIXLPER_INSTALL_DIR/custom` when not explicitly set.
+
+### Update detection (`functions_update.sh`)
+
+Two channels selected via `NIXLPER_UPDATE_CHANNEL`: `stable` (compares installed `VERSION:`
+against GitHub `releases/latest`), `edge` (compares installed full `COMMIT:` SHA against the
+latest commit on `main`), and `off`. All network access is gated by `_i_is_online` — a
+time-boxed `curl` reachability probe — so an offline machine never hangs or errors at login.
+Automatic startup checks are throttled via `NIXLPER_UPDATE_CACHE_FILE`; the `nu` / `CTRL+X+W`
+command bypasses the throttle and always reports. The `edge` channel relies on `build.sh`
+writing the full SHA (`COMMIT:`) into the `version` file, and on CI's rolling `edge`
+pre-release (`.github/workflows/publish_edge_on_push.yml`), which is excluded from
+`create_release_on_tag.yml` via a `!edge` tag filter. `install.sh` accepts `--channel
+stable|edge` and `--yes`, and aborts cleanly when the internet is unreachable.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,6 +400,11 @@ pre-release (`.github/workflows/publish_edge_on_push.yml`), which is excluded fr
 `create_release_on_tag.yml` via a `!edge` tag filter. `install.sh` accepts `--channel
 stable|edge` and `--yes`, and aborts cleanly when the internet is unreachable.
 
+Automated tests live in `src/test/bash/test_functions_update.sh` (pure bash, no framework,
+fully offline — network helpers are mocked). They run in CI via `.github/workflows/tests.yml`
+on every push and PR, alongside a `bash -n` syntax check of all bash sources. Run locally with
+`bash src/test/bash/test_functions_update.sh`.
+
 ---
 
 ## RPM Packaging

--- a/README.md
+++ b/README.md
@@ -301,6 +301,33 @@ aliases and functions.
 
 - `CTRL + X then V`: display the Nixlper logo with version information and git SHA
 
+### Updates
+
+Nixlper can detect when a newer version is available and suggest updating. A check runs automatically at shell start (throttled) and on demand.
+
+- `CTRL + X then W` (or `nu`): check for a newer version on the active update channel
+
+Two channels are available via `NIXLPER_UPDATE_CHANNEL`:
+
+| Channel | Behavior |
+|---|---|
+| `stable` (default) | Tracks tagged releases — notifies when a newer tag exists. |
+| `edge` | Tracks the latest commit — notifies when a new commit was pushed (CI keeps a rolling `edge` pre-release updated on every push). |
+| `off` | Disables all checks and network access. |
+
+Updating when notified:
+
+```bash
+# stable channel
+curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh | bash
+# edge channel (latest commit)
+curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh | bash -s -- --channel edge
+```
+
+**Internet is required.** When offline, the automatic check is skipped silently and never hangs (the probe is capped by `NIXLPER_UPDATE_TIMEOUT`, default 2s). Set `NIXLPER_UPDATE_CHANNEL=off` to disable checks entirely.
+
+Set `NIXLPER_UPDATE_AUTO=true` to install a detected update automatically (default is notify-only). Other tunables: `NIXLPER_UPDATE_CHECK` (true/false) and `NIXLPER_UPDATE_CHECK_INTERVAL` (seconds between automatic checks, default `86400`).
+
 ### Tips
 
 A tip is shown automatically at each shell start (cycling through all tips in order).

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,7 @@ function _create_sha_version_file() {
   local -r git_tag=$(git describe --tags --exact-match HEAD 2>&1)
   local -r git_time=$(git log -n 1 --pretty=format:%ad --date=format:'%Y-%m-%d')
   local -r git_short_sha=$(git log -n 1 --pretty=format:%h)
+  local -r git_sha=$(git log -n 1 --pretty=format:%H)
   echo "👉 Create version file (git sha)"
   {
     echo "PROJECT: ${PROJECT_NAME}"
@@ -47,6 +48,8 @@ function _create_sha_version_file() {
       echo "VERSION: ${git_tag}"
     fi
     echo "TECHNICAL VERSION: ${git_short_sha} (${git_time})"
+    # Full SHA — consumed by the edge update channel to detect a newer commit.
+    echo "COMMIT: ${git_sha}"
   } >> "${SHA_VERSION_FILE}"
   _log_ok
 }

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,17 @@ _check_prerequisites() {
 }
 
 #***********************************************************************************************************************
+# Internet reachability — install/update is impossible (and must be disabled) when offline.
+#***********************************************************************************************************************
+_check_internet() {
+  if ! curl -fsS --max-time 5 -o /dev/null "https://api.github.com" 2>/dev/null; then
+    _log_error "Internet is not reachable — cannot fetch Nixlper. Install/update disabled."
+    _log_info "Reconnect and try again, or set NIXLPER_UPDATE_CHANNEL=off to silence update checks."
+    exit 1
+  fi
+}
+
+#***********************************************************************************************************************
 # GitHub release helpers
 #***********************************************************************************************************************
 _get_latest_release_tag() {
@@ -217,15 +228,33 @@ _update_install() {
 #***********************************************************************************************************************
 main() {
   local system_mode=false
-  if [[ "${1:-}" == "--system" ]]; then
-    system_mode=true
+  local assume_yes=false
+  local channel="stable"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --system) system_mode=true ;;
+      --yes|-y) assume_yes=true ;;
+      --channel)
+        shift
+        channel="${1:-stable}"
+        ;;
+      --channel=*) channel="${1#--channel=}" ;;
+      *) _log_error "Unknown option: $1"; exit 1 ;;
+    esac
+    shift
+  done
+
+  if [[ "${channel}" != "stable" && "${channel}" != "edge" ]]; then
+    _log_error "Invalid --channel '${channel}' (use stable or edge)"
+    exit 1
   fi
 
   _log_separator
   if [[ "${system_mode}" == "true" ]]; then
-    echo "  Nixlper Installer (system-wide)"
+    echo "  Nixlper Installer (system-wide, ${channel} channel)"
   else
-    echo "  Nixlper Installer"
+    echo "  Nixlper Installer (${channel} channel)"
   fi
   _log_separator
   echo ""
@@ -236,11 +265,19 @@ main() {
   fi
 
   _check_prerequisites
+  _check_internet
 
-  # Determine the latest release
-  _log_info "Fetching latest release information from GitHub ..."
-  local -r tag=$(_get_latest_release_tag)
-  _log_ok "Latest release: ${tag}"
+  # Determine what to install for the selected channel.
+  local tag
+  if [[ "${channel}" == "edge" ]]; then
+    # The edge channel tracks a single rolling pre-release, overwritten by CI on every push.
+    tag="edge"
+    _log_info "Edge channel — installing the latest commit build (${tag})"
+  else
+    _log_info "Fetching latest release information from GitHub ..."
+    tag=$(_get_latest_release_tag)
+    _log_ok "Latest release: ${tag}"
+  fi
   echo ""
 
   if _is_nixlper_installed; then
@@ -255,8 +292,11 @@ main() {
 
     _log_info "Nixlper is already installed in ${install_dir}"
     echo ""
-    read -r -p "Do you want to update to version ${tag}? [Y/n] " answer
-    answer=${answer:-Y}
+    local answer="Y"
+    if [[ "${assume_yes}" != "true" ]]; then
+      read -r -p "Do you want to update to ${tag}? [Y/n] " answer
+      answer=${answer:-Y}
+    fi
     if [[ "${answer}" =~ ^[Yy]$ ]]; then
       local archive_path
       archive_path=$(_download_release "${tag}" "${install_dir}")
@@ -268,14 +308,19 @@ main() {
     # ----- FIRST INSTALL PATH -----
     local install_dir="${DEFAULT_INSTALL_DIR}"
 
-    echo "Nixlper is not installed on this system."
-    read -r -p "Install directory [${DEFAULT_INSTALL_DIR}]: " custom_dir
-    if [[ -n "${custom_dir}" ]]; then
-      install_dir="${custom_dir}"
+    if [[ "${assume_yes}" != "true" ]]; then
+      echo "Nixlper is not installed on this system."
+      read -r -p "Install directory [${DEFAULT_INSTALL_DIR}]: " custom_dir
+      if [[ -n "${custom_dir}" ]]; then
+        install_dir="${custom_dir}"
+      fi
     fi
 
-    read -r -p "Install Nixlper ${tag} into ${install_dir}? [Y/n] " answer
-    answer=${answer:-Y}
+    local answer="Y"
+    if [[ "${assume_yes}" != "true" ]]; then
+      read -r -p "Install Nixlper ${tag} into ${install_dir}? [Y/n] " answer
+      answer=${answer:-Y}
+    fi
     if [[ "${answer}" =~ ^[Yy]$ ]]; then
       local archive_path
       archive_path=$(_download_release "${tag}" "/tmp")

--- a/packaging/shared/nixlper.conf
+++ b/packaging/shared/nixlper.conf
@@ -8,8 +8,16 @@ export NIXLPER_NAVIGATE_MODE="${NIXLPER_NAVIGATE_MODE:-tree}"
 export NIXLPER_EDITOR="${NIXLPER_EDITOR:-vim}"
 export NIXLPER_DISABLE_WELCOME_MESSAGE="${NIXLPER_DISABLE_WELCOME_MESSAGE:-false}"
 
+# Update detection — channel is stable|edge|off (see README → Updates).
+export NIXLPER_UPDATE_CHANNEL="${NIXLPER_UPDATE_CHANNEL:-stable}"
+export NIXLPER_UPDATE_CHECK="${NIXLPER_UPDATE_CHECK:-true}"
+export NIXLPER_UPDATE_AUTO="${NIXLPER_UPDATE_AUTO:-false}"
+export NIXLPER_UPDATE_CHECK_INTERVAL="${NIXLPER_UPDATE_CHECK_INTERVAL:-86400}"
+export NIXLPER_UPDATE_TIMEOUT="${NIXLPER_UPDATE_TIMEOUT:-2}"
+
 # Per-user paths — $HOME expands at login time for each user.
 export NIXLPER_BOOKMARKS_FILE="${NIXLPER_BOOKMARKS_FILE:-${HOME}/.local/share/nixlper/bookmarks}"
 export NIXLPER_LAST_MACRO_BINDING_FILE="${NIXLPER_LAST_MACRO_BINDING_FILE:-${HOME}/.local/share/nixlper/last_macro_binding}"
 export NIXLPER_SNAPSHOT_DIR="${NIXLPER_SNAPSHOT_DIR:-${HOME}/.local/share/nixlper/snapshots}"
 export NIXLPER_CUSTOM_DIR="${NIXLPER_CUSTOM_DIR:-${HOME}/.config/nixlper/custom}"
+export NIXLPER_UPDATE_CACHE_FILE="${NIXLPER_UPDATE_CACHE_FILE:-${HOME}/.local/share/nixlper/update_check}"

--- a/src/main/bash/functions_update.sh
+++ b/src/main/bash/functions_update.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: functions_update.sh
+# DESCRIPTION: update detection across release channels (stable / edge) with an offline guard.
+#
+# Channels are selected with NIXLPER_UPDATE_CHANNEL:
+#   stable (default) — track tagged GitHub releases; suggest an update when a newer tag exists.
+#   edge             — track the latest commit on the default branch (a rolling "edge" pre-release
+#                      is overwritten by CI on every push); suggest an update when HEAD moved.
+#   off              — never touch the network, never check.
+#
+# All network access is gated by _i_is_online (a fast, time-boxed reachability probe), so a
+# disconnected machine never hangs or errors at login. Automatic startup checks are throttled
+# to NIXLPER_UPDATE_CHECK_INTERVAL seconds via a per-user cache file; the on-demand command
+# (_check_update / alias nu / CTRL+X+W) bypasses the throttle and always reports a result.
+########################################################################################################################
+
+readonly NIXLPER_GITHUB_REPO="Minhounet/nixlper"
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Internal helpers
+#-----------------------------------------------------------------------------------------------------------------------
+# Per-user, always-writable cache file holding the epoch of the last successful check.
+function _i_update_cache_file() {
+  echo "${NIXLPER_UPDATE_CACHE_FILE:-${NIXLPER_INSTALL_DIR}/.nixlper_update_check}"
+}
+
+# Return 0 if GitHub is reachable within NIXLPER_UPDATE_TIMEOUT seconds, 1 otherwise.
+function _i_is_online() {
+  command -v curl >/dev/null 2>&1 || return 1
+  curl -fsS --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" -o /dev/null "https://api.github.com" 2>/dev/null
+}
+
+# Echo a field from the installed version file (e.g. "VERSION:" or "COMMIT:"), empty if absent.
+function _i_installed_version_field() {
+  local -r field="$1"
+  local -r version_file="${NIXLPER_INSTALL_DIR}/version"
+  [[ -f "${version_file}" ]] || return 0
+  grep -m1 "^${field}" "${version_file}" 2>/dev/null | sed "s/^${field}[[:space:]]*//"
+}
+
+# Latest published (non-prerelease) release tag, empty on failure.
+function _i_remote_latest_tag() {
+  curl -fsSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
+    "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/releases/latest" 2>/dev/null \
+    | grep '"tag_name"' \
+    | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/'
+}
+
+# Latest commit SHA on the default branch, empty on failure.
+function _i_remote_latest_commit() {
+  curl -fsSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
+    "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/commits/main" 2>/dev/null \
+    | grep -m1 '"sha"' \
+    | sed -E 's/.*"sha":[[:space:]]*"([^"]+)".*/\1/'
+}
+
+# Return 0 if $1 is a strictly greater version than $2 (version sort), avoiding false
+# "downgrade" suggestions when a dev/edge build runs on the stable channel.
+function _i_version_gt() {
+  [[ "$1" != "$2" ]] && [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" == "$1" ]]
+}
+
+# Return 0 if an automatic check is due (throttle elapsed or no prior check).
+function _i_update_check_due() {
+  local -r cache_file="$(_i_update_cache_file)"
+  local -r interval="${NIXLPER_UPDATE_CHECK_INTERVAL:-86400}"
+  [[ -f "${cache_file}" ]] || return 0
+  local last
+  last=$(cat "${cache_file}" 2>/dev/null)
+  [[ "${last}" =~ ^[0-9]+$ ]] || return 0
+  (( $(date +%s) - last >= interval ))
+}
+
+# Stamp the cache file with the current time so we don't re-check until the interval elapses.
+function _i_update_touch_cache() {
+  local -r cache_file="$(_i_update_cache_file)"
+  mkdir -p "$(dirname "${cache_file}")" 2>/dev/null
+  date +%s > "${cache_file}" 2>/dev/null || true
+}
+
+# Optional opt-in auto-update (NIXLPER_UPDATE_AUTO=true). $1 = channel flag for install.sh.
+function _i_maybe_auto_update() {
+  local -r channel="${1:-stable}"
+  [[ "${NIXLPER_UPDATE_AUTO:-false}" == "true" ]] || return 0
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "⚠️  NIXLPER_UPDATE_AUTO is on but curl is missing — skipping auto-update."
+    return 0
+  fi
+  echo "⬆️  NIXLPER_UPDATE_AUTO is on — updating to the latest ${channel} build..."
+  curl -fsSL "https://raw.githubusercontent.com/${NIXLPER_GITHUB_REPO}/main/install.sh" \
+    | bash -s -- --yes --channel "${channel}"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Channel checks
+#-----------------------------------------------------------------------------------------------------------------------
+function _i_check_stable() {
+  local -r force="${1:-false}"
+  local installed latest
+  installed=$(_i_installed_version_field "VERSION:")
+  latest=$(_i_remote_latest_tag)
+
+  if [[ -z "${latest}" ]]; then
+    [[ "${force}" == "true" ]] && echo "⚠️  Could not determine the latest release."
+    return 0
+  fi
+
+  if [[ -z "${installed}" ]]; then
+    [[ "${force}" == "true" ]] && echo "🔔 Latest release is ${latest} (installed version unknown)."
+    return 0
+  fi
+
+  if _i_version_gt "${latest}" "${installed}"; then
+    echo "🔔 Nixlper ${latest} is available (you have ${installed})."
+    echo "   Update: curl -fsSL https://raw.githubusercontent.com/${NIXLPER_GITHUB_REPO}/main/install.sh | bash"
+    _i_maybe_auto_update stable
+  else
+    [[ "${force}" == "true" ]] && echo "✅ Nixlper is up to date (${installed})."
+  fi
+}
+
+function _i_check_edge() {
+  local -r force="${1:-false}"
+  local installed latest
+  installed=$(_i_installed_version_field "COMMIT:")
+  latest=$(_i_remote_latest_commit)
+
+  if [[ -z "${latest}" ]]; then
+    [[ "${force}" == "true" ]] && echo "⚠️  Could not determine the latest commit."
+    return 0
+  fi
+
+  if [[ -z "${installed}" ]]; then
+    [[ "${force}" == "true" ]] && echo "🔔 Latest commit is ${latest:0:7} (installed commit unknown)."
+    return 0
+  fi
+
+  if [[ "${installed}" == "${latest}" ]]; then
+    [[ "${force}" == "true" ]] && echo "✅ Nixlper is at the latest commit (${latest:0:7})."
+  else
+    echo "🔔 A newer Nixlper commit is available (${latest:0:7}, you have ${installed:0:7})."
+    echo "   Update: curl -fsSL https://raw.githubusercontent.com/${NIXLPER_GITHUB_REPO}/main/install.sh | bash -s -- --channel edge"
+    _i_maybe_auto_update edge
+  fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Public entry points
+#-----------------------------------------------------------------------------------------------------------------------
+# Core checker. $1 = "true" to force (bypass throttle and speak even when up to date).
+function _i_check_for_updates() {
+  local -r force="${1:-false}"
+  local -r channel="${NIXLPER_UPDATE_CHANNEL:-stable}"
+
+  if [[ "${channel}" == "off" || "${NIXLPER_UPDATE_CHECK:-true}" == "false" ]]; then
+    [[ "${force}" == "true" ]] && echo "ℹ️  Update checks are disabled (channel=off or NIXLPER_UPDATE_CHECK=false)."
+    return 0
+  fi
+
+  if [[ "${force}" != "true" ]] && ! _i_update_check_due; then
+    return 0
+  fi
+
+  if ! _i_is_online; then
+    [[ "${force}" == "true" ]] && echo "📡 Internet not reachable — update check skipped."
+    return 0
+  fi
+
+  # Stamp now so a failed lookup still respects the throttle and we don't hammer GitHub.
+  _i_update_touch_cache
+
+  case "${channel}" in
+    stable) _i_check_stable "${force}" ;;
+    edge)   _i_check_edge "${force}" ;;
+    *)      [[ "${force}" == "true" ]] && echo "⚠️  Unknown NIXLPER_UPDATE_CHANNEL='${channel}' (use stable|edge|off)." ;;
+  esac
+}
+
+# @cmd-palette
+# @description: Check for a newer Nixlper version on the active update channel
+# @category: Updates
+# @keybind: CTRL+X+W
+# @alias: nu
+function _check_update() {
+  _i_check_for_updates true
+}

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -20,6 +20,7 @@ function _i_init() {
   _i_load_bindings
   _i_load_custom_libraries
   _i_load_tips
+  _i_check_for_updates
 }
 
 function _i_test_prerequisites() {
@@ -162,12 +163,18 @@ export NIXLPER_INSTALL_DIR="\${NIXLPER_INSTALL_DIR:-${install_dir}}"
 export NIXLPER_NAVIGATE_MODE="\${NIXLPER_NAVIGATE_MODE:-tree}"
 export NIXLPER_EDITOR="\${NIXLPER_EDITOR:-vim}"
 export NIXLPER_DISABLE_WELCOME_MESSAGE="\${NIXLPER_DISABLE_WELCOME_MESSAGE:-false}"
+export NIXLPER_UPDATE_CHANNEL="\${NIXLPER_UPDATE_CHANNEL:-stable}"
+export NIXLPER_UPDATE_CHECK="\${NIXLPER_UPDATE_CHECK:-true}"
+export NIXLPER_UPDATE_AUTO="\${NIXLPER_UPDATE_AUTO:-false}"
+export NIXLPER_UPDATE_CHECK_INTERVAL="\${NIXLPER_UPDATE_CHECK_INTERVAL:-86400}"
+export NIXLPER_UPDATE_TIMEOUT="\${NIXLPER_UPDATE_TIMEOUT:-2}"
 
 # Per-user paths — \$HOME expands at login time for each user.
 export NIXLPER_BOOKMARKS_FILE="\${NIXLPER_BOOKMARKS_FILE:-\${HOME}/.local/share/nixlper/bookmarks}"
 export NIXLPER_LAST_MACRO_BINDING_FILE="\${NIXLPER_LAST_MACRO_BINDING_FILE:-\${HOME}/.local/share/nixlper/last_macro_binding}"
 export NIXLPER_SNAPSHOT_DIR="\${NIXLPER_SNAPSHOT_DIR:-\${HOME}/.local/share/nixlper/snapshots}"
 export NIXLPER_CUSTOM_DIR="\${NIXLPER_CUSTOM_DIR:-\${HOME}/.config/nixlper/custom}"
+export NIXLPER_UPDATE_CACHE_FILE="\${NIXLPER_UPDATE_CACHE_FILE:-\${HOME}/.local/share/nixlper/update_check}"
 EOF
   chmod 644 /etc/nixlper/nixlper.conf
 
@@ -225,6 +232,12 @@ function _i_set_bashrc_config() {
   echo "export NIXLPER_NAVIGATE_MODE=tree" >> ~/.bashrc
   echo "export NIXLPER_EDITOR=vim" >> ~/.bashrc
   echo "export NIXLPER_DISABLE_WELCOME_MESSAGE=false" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_CHANNEL=stable" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_CHECK=true" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_AUTO=false" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_CHECK_INTERVAL=86400" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_TIMEOUT=2" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_CACHE_FILE=\${NIXLPER_INSTALL_DIR}/.nixlper_update_check" >> ~/.bashrc
   echo "source \${NIXLPER_INSTALL_DIR}/nixlper.sh" >> ~/.bashrc
   echo "################################ nixlper stop ##################################################" >> ~/.bashrc
   source ~/.bashrc
@@ -252,6 +265,9 @@ function _i_load_bindings() {
 
     # version and logo - annotation already in functions_version.sh
     bind -x '"\C-x\C-v": _display_logo_and_version'
+
+    # update check - annotation already in functions_update.sh
+    bind -x '"\C-x\C-w": _check_update'
 
     # files
     # @cmd-palette
@@ -359,6 +375,7 @@ alias sr=start_recording
 alias fr=finalize_recording
 alias fa=find_action
 alias tip=show_random_tip
+alias nu=_check_update
 
 #***********************************************************************************************************************
 ########################################################################################################################

--- a/src/main/help/help_updates
+++ b/src/main/help/help_updates
@@ -1,0 +1,32 @@
+########################################################################################################################
+# Help for updates
+########################################################################################################################
+------------------------------------------------------------------------------------------------------------------------
+[CTRL + X THEN W] or  nu : check for a newer Nixlper version on the active update channel
+------------------------------------------------------------------------------------------------------------------------
+Nixlper can detect when a newer version is available and suggest updating. A check runs
+automatically at shell start (throttled), and  nu  / CTRL+X+W triggers one on demand.
+
+Channels (NIXLPER_UPDATE_CHANNEL):
+  stable  (default) : track tagged releases; notify when a newer tag exists.
+  edge              : track the latest commit; notify when a new commit was pushed.
+  off               : disable all checks and network access.
+
+Internet must be reachable. When offline, the automatic check is skipped silently and never
+hangs (probe capped by NIXLPER_UPDATE_TIMEOUT seconds). Set NIXLPER_UPDATE_CHANNEL=off to
+disable checks entirely.
+
+Updating when notified:
+  stable : curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh | bash
+  edge   : curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh | bash -s -- --channel edge
+
+Opt-in automatic update: set  export NIXLPER_UPDATE_AUTO=true  to install the new build
+immediately when one is detected (default is notify-only).
+
+Relevant config variables:
+  NIXLPER_UPDATE_CHANNEL        stable | edge | off       (default stable)
+  NIXLPER_UPDATE_CHECK          true | false              (default true)
+  NIXLPER_UPDATE_AUTO           true | false              (default false)
+  NIXLPER_UPDATE_CHECK_INTERVAL seconds between checks     (default 86400)
+  NIXLPER_UPDATE_TIMEOUT        reachability timeout (s)   (default 2)
+------------------------------------------------------------------------------------------------------------------------

--- a/src/test/bash/test_functions_update.sh
+++ b/src/test/bash/test_functions_update.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: test_functions_update.sh
+# DESCRIPTION: Offline unit tests for the update-detection feature (functions_update.sh).
+#
+# These tests are dependency-free (pure bash) and never touch the network: the reachability
+# probe and the GitHub lookups are overridden with mocks, so they run deterministically in CI.
+# Run locally with:  bash src/test/bash/test_functions_update.sh
+########################################################################################################################
+set -u
+
+# Resolve repo root from this script's location so it works from any CWD (incl. CI).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+MODULE="${REPO_ROOT}/src/main/bash/functions_update.sh"
+
+if [[ ! -f "${MODULE}" ]]; then
+  echo "❌ Cannot find module under test: ${MODULE}" >&2
+  exit 1
+fi
+
+# Isolated, throwaway install dir / cache so tests never read or write a real installation.
+export NIXLPER_INSTALL_DIR="$(mktemp -d)"
+export NIXLPER_UPDATE_CACHE_FILE="${NIXLPER_INSTALL_DIR}/.nixlper_update_check"
+trap 'rm -rf "${NIXLPER_INSTALL_DIR}"' EXIT
+
+# shellcheck source=/dev/null
+source "${MODULE}"
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Tiny assertion helpers
+#-----------------------------------------------------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+_expect_eq() {
+  local -r name="$1" got="$2" want="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    echo "  ✅ ${name}"
+    PASS=$((PASS + 1))
+  else
+    echo "  ❌ ${name}: got [${got}] want [${want}]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# $3 = expected count of lines matching the regex in $2 (stdout+stderr of last captured run)
+_expect_match_count() {
+  local -r name="$1" haystack="$2" regex="$3" want="$4"
+  local got
+  got="$(printf '%s\n' "${haystack}" | grep -c -E "${regex}")"
+  _expect_eq "${name}" "${got}" "${want}"
+}
+
+_expect_true() {  # $2 is a command; passes if it returns 0
+  local -r name="$1"; shift
+  if "$@"; then echo "  ✅ ${name}"; PASS=$((PASS + 1)); else echo "  ❌ ${name}: expected success"; FAIL=$((FAIL + 1)); fi
+}
+
+_expect_false() {  # passes if command returns non-zero
+  local -r name="$1"; shift
+  if "$@"; then echo "  ❌ ${name}: expected failure"; FAIL=$((FAIL + 1)); else echo "  ✅ ${name}"; PASS=$((PASS + 1)); fi
+}
+
+_write_version() {  # $1 VERSION value (may be empty), $2 COMMIT value (may be empty)
+  {
+    echo "PROJECT: nixlper"
+    [[ -n "${1:-}" ]] && echo "VERSION: $1"
+    echo "TECHNICAL VERSION: abc123 (2026-01-01)"
+    [[ -n "${2:-}" ]] && echo "COMMIT: $2"
+  } > "${NIXLPER_INSTALL_DIR}/version"
+}
+
+_reset_throttle() { rm -f "${NIXLPER_UPDATE_CACHE_FILE}"; }
+
+# Default mocks — individual tests override as needed.
+_i_is_online() { return 0; }
+_i_remote_latest_tag() { echo ""; }
+_i_remote_latest_commit() { echo ""; }
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _i_version_gt =="
+_expect_true  "2.1.0 > 2.0.1"            _i_version_gt v2.1.0 v2.0.1
+_expect_false "2.0.1 not > 2.1.0"        _i_version_gt v2.0.1 v2.1.0
+_expect_false "equal is not greater"     _i_version_gt v2.0.1 v2.0.1
+_expect_true  "2.0.10 > 2.0.9 (numeric)" _i_version_gt v2.0.10 v2.0.9
+
+echo "== version file parsing =="
+_write_version "v2.0.1" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+_expect_eq "VERSION field" "$(_i_installed_version_field 'VERSION:')" "v2.0.1"
+_expect_eq "COMMIT field"  "$(_i_installed_version_field 'COMMIT:')" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+_write_version "" ""
+_expect_eq "missing VERSION -> empty" "$(_i_installed_version_field 'VERSION:')" ""
+
+echo "== throttle =="
+_reset_throttle
+_expect_true  "due when no cache exists"  _i_update_check_due
+_i_update_touch_cache
+_expect_false "not due right after stamp" _i_update_check_due
+echo "garbage" > "${NIXLPER_UPDATE_CACHE_FILE}"
+_expect_true  "due when cache is corrupt" _i_update_check_due
+
+echo "== channel: off =="
+export NIXLPER_UPDATE_CHANNEL=off
+_reset_throttle
+_expect_eq "off + auto is silent" "$(_i_check_for_updates 2>&1)" ""
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "off + force explains" "${out}" "disabled" 1
+
+echo "== channel: NIXLPER_UPDATE_CHECK=false =="
+export NIXLPER_UPDATE_CHANNEL=stable
+export NIXLPER_UPDATE_CHECK=false
+_reset_throttle
+_expect_eq "check=false auto silent" "$(_i_check_for_updates 2>&1)" ""
+unset NIXLPER_UPDATE_CHECK
+
+echo "== offline guard =="
+export NIXLPER_UPDATE_CHANNEL=stable
+_i_is_online() { return 1; }
+_reset_throttle
+_expect_eq "offline auto is silent" "$(_i_check_for_updates 2>&1)" ""
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "offline force reports" "${out}" "not reachable" 1
+_i_is_online() { return 0; }
+
+echo "== stable channel =="
+_write_version "v2.0.1" ""
+_i_remote_latest_tag() { echo "v2.1.0"; }
+_reset_throttle
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "newer tag notifies" "${out}" "v2.1.0 is available" 1
+_i_remote_latest_tag() { echo "v2.0.1"; }
+_reset_throttle
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "same tag: up to date (force)" "${out}" "up to date" 1
+_reset_throttle
+_expect_eq "same tag: silent on auto" "$(_i_check_for_updates 2>&1)" ""
+# Installed newer than remote (dev build) must NOT suggest a downgrade.
+_write_version "v2.5.0" ""
+_i_remote_latest_tag() { echo "v2.1.0"; }
+_reset_throttle
+out="$(_i_check_for_updates 2>&1)"
+_expect_eq "newer-than-remote: no downgrade noise" "${out}" ""
+
+echo "== edge channel =="
+export NIXLPER_UPDATE_CHANNEL=edge
+_write_version "" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+_i_remote_latest_commit() { echo "1111111111111111111111111111111111111111"; }
+_reset_throttle
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "new commit notifies" "${out}" "newer Nixlper commit" 1
+_i_remote_latest_commit() { echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; }
+_reset_throttle
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "same commit: up to date" "${out}" "latest commit" 1
+
+echo "== unknown channel =="
+export NIXLPER_UPDATE_CHANNEL=bogus
+_reset_throttle
+out="$(_i_check_for_updates true 2>&1)"
+_expect_match_count "unknown channel warns" "${out}" "Unknown NIXLPER_UPDATE_CHANNEL" 1
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo ""
+echo "====================================================================================================="
+echo "RESULT: ${PASS} passed, ${FAIL} failed"
+echo "====================================================================================================="
+[[ ${FAIL} -eq 0 ]]


### PR DESCRIPTION
Introduce NIXLPER_UPDATE_CHANNEL with three modes:
- stable (default): compare installed VERSION against the latest GitHub release tag
  and suggest updating when a newer tag exists.
- edge: compare installed full commit SHA against the latest commit on main, backed
  by a rolling "edge" pre-release that CI overwrites on every push.
- off: disable all checks and network access.

All network access is gated by a time-boxed reachability probe so an offline machine
never hangs or errors at login; automatic startup checks are throttled (24h default)
and the on-demand check (nu / CTRL+X+W) bypasses the throttle. Opt-in auto-update via
NIXLPER_UPDATE_AUTO (default notify-only). install.sh gains --channel and --yes plus an
internet check. build.sh records the full COMMIT SHA for edge comparison. Docs, help,
config templates, and CLAUDE.md updated.