### PR TITLE
✨feat|Preserve install channel through update/install flow.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -300,7 +300,7 @@ main() {
     if [[ "${answer}" =~ ^[Yy]$ ]]; then
       local archive_path
       archive_path=$(_download_release "${tag}" "${install_dir}")
-      _update_install "${install_dir}" "${archive_path}" "${system_mode}"
+      NIXLPER_INSTALL_CHANNEL="${channel}" _update_install "${install_dir}" "${archive_path}" "${system_mode}"
     else
       _log_info "Update cancelled"
     fi
@@ -324,7 +324,7 @@ main() {
     if [[ "${answer}" =~ ^[Yy]$ ]]; then
       local archive_path
       archive_path=$(_download_release "${tag}" "/tmp")
-      _first_install "${install_dir}" "/tmp/$(basename "${archive_path}")" "${system_mode}"
+      NIXLPER_INSTALL_CHANNEL="${channel}" _first_install "${install_dir}" "/tmp/$(basename "${archive_path}")" "${system_mode}"
     else
       _log_info "Installation cancelled"
     fi

--- a/src/main/bash/functions_update.sh
+++ b/src/main/bash/functions_update.sh
@@ -111,6 +111,13 @@ function _i_check_stable() {
     return 0
   fi
 
+  # Guard: if the installed value doesn't look like a semver tag (e.g. it's "edge"),
+  # the stable check is meaningless — skip silently to avoid a false positive.
+  if [[ ! "${installed}" =~ ^v?[0-9]+\.[0-9]+ ]]; then
+    [[ "${force}" == "true" ]] && echo "ℹ️  Installed build ('${installed}') is not a stable release — skipping stable channel check."
+    return 0
+  fi
+
   if _i_version_gt "${latest}" "${installed}"; then
     echo "🔔 Nixlper ${latest} is available (you have ${installed})."
     echo "   Update: curl -fsSL https://raw.githubusercontent.com/${NIXLPER_GITHUB_REPO}/main/install.sh | bash"

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -163,7 +163,7 @@ export NIXLPER_INSTALL_DIR="\${NIXLPER_INSTALL_DIR:-${install_dir}}"
 export NIXLPER_NAVIGATE_MODE="\${NIXLPER_NAVIGATE_MODE:-tree}"
 export NIXLPER_EDITOR="\${NIXLPER_EDITOR:-vim}"
 export NIXLPER_DISABLE_WELCOME_MESSAGE="\${NIXLPER_DISABLE_WELCOME_MESSAGE:-false}"
-export NIXLPER_UPDATE_CHANNEL="\${NIXLPER_UPDATE_CHANNEL:-stable}"
+export NIXLPER_UPDATE_CHANNEL="\${NIXLPER_UPDATE_CHANNEL:-${NIXLPER_INSTALL_CHANNEL:-stable}}"
 export NIXLPER_UPDATE_CHECK="\${NIXLPER_UPDATE_CHECK:-true}"
 export NIXLPER_UPDATE_AUTO="\${NIXLPER_UPDATE_AUTO:-false}"
 export NIXLPER_UPDATE_CHECK_INTERVAL="\${NIXLPER_UPDATE_CHECK_INTERVAL:-86400}"
@@ -232,7 +232,7 @@ function _i_set_bashrc_config() {
   echo "export NIXLPER_NAVIGATE_MODE=tree" >> ~/.bashrc
   echo "export NIXLPER_EDITOR=vim" >> ~/.bashrc
   echo "export NIXLPER_DISABLE_WELCOME_MESSAGE=false" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_CHANNEL=stable" >> ~/.bashrc
+  echo "export NIXLPER_UPDATE_CHANNEL=${NIXLPER_INSTALL_CHANNEL:-stable}" >> ~/.bashrc
   echo "export NIXLPER_UPDATE_CHECK=true" >> ~/.bashrc
   echo "export NIXLPER_UPDATE_AUTO=false" >> ~/.bashrc
   echo "export NIXLPER_UPDATE_CHECK_INTERVAL=86400" >> ~/.bashrc


### PR DESCRIPTION
## Summary
Ensures that the installation channel (e.g., `edge`, `stable`) selected during initial installation or update is preserved and propagated through the entire installation process, so that subsequent update checks use the same channel.

## Changes

- **`install.sh`**: Pass `NIXLPER_INSTALL_CHANNEL` environment variable to `_update_install()` and `_first_install()` functions so the selected channel is available during installation.

- **`src/main/bash/nixlper.sh`**: 
  - Update `NIXLPER_UPDATE_CHANNEL` default to respect `NIXLPER_INSTALL_CHANNEL` if set during installation, falling back to `stable`.
  - Update `.bashrc` configuration to persist the install channel as the update channel.

- **`src/main/bash/functions_update.sh`**: Add guard in `_i_check_stable()` to skip the stable release check if the installed version is not a valid semver tag (e.g., `edge`), preventing false positives when checking non-stable builds.

## Implementation Details

The channel selection is now threaded through the installation process:
1. User selects a channel during install/update
2. Channel is passed via `NIXLPER_INSTALL_CHANNEL` to installation functions
3. `nixlper.sh` uses this value to set `NIXLPER_UPDATE_CHANNEL` for future update checks
4. `.bashrc` configuration persists the channel for the user's shell environment
5. Non-semver versions (like `edge`) are gracefully skipped during stable release checks

https://claude.ai/code/session_01J77UChLWhaCMxBGyTPvn7X