### PR TITLE
📝docs|Clarify macro restore keybinding and playback workflow.

### DIFF
--- a/src/main/bash/functions_macros.sh
+++ b/src/main/bash/functions_macros.sh
@@ -85,7 +85,7 @@ function _prepare_binding() {
 }
 
 # @cmd-palette
-# @description: Replay last recorded macro
+# @description: Restore last macro binding — then press CTRL+X+CTRL+X to play
 # @category: Macros
 # @keybind: CTRL+P+CTRL+L
 function bind_last_macro() {

--- a/src/main/help/help_macros
+++ b/src/main/help/help_macros
@@ -3,4 +3,5 @@
 ########################################################################################################################
 - `CTRL + P`: start recording
 - `CTRL + P, CTRL + P`: stop recording
+- `CTRL + P, CTRL + L`: restore last macro binding (new shell session) — then press CTRL+X+CTRL+X to play
 - `CTRL + X, CTRL + X`: play recorded commands


### PR DESCRIPTION
## Summary
Updated documentation and function description for the macro restore feature to clarify the two-step workflow: restore the binding with `CTRL+P+CTRL+L`, then play it with `CTRL+X+CTRL+X`.

## Changes
- **`functions_macros.sh`**: Updated `bind_last_macro()` description from "Replay last recorded macro" to "Restore last macro binding — then press CTRL+X+CTRL+X to play" to accurately reflect that this command restores the binding for a new shell session rather than immediately replaying it.
- **`help_macros`**: Added new help entry documenting the `CTRL+P+CTRL+L` keybinding and its purpose, clarifying the two-step process for users.

## Implementation Details
The changes clarify user expectations around macro persistence across shell sessions. The `bind_last_macro()` function restores a previously recorded macro binding (useful when starting a new shell), but playback requires a separate `CTRL+X+CTRL+X` command. This distinction is now explicit in both the command palette and help documentation.

https://claude.ai/code/session_01KBARsMJx8FHDbn5ADjiiWX