### PR TITLE
📝docs|Clarify navigation shortcuts (vN, cdfN, dN) in help and README.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,26 @@ commit that fixes the underlying bug.
 
 ---
 
+## ⚠️ MANDATORY: Documentation Completeness — NEVER SKIP
+
+**After every code change, you MUST update ALL of the following that are affected. This is not optional and must never be skipped, even for "small" changes.**
+
+### Checklist — run through this after every task
+
+1. **`src/main/help/help_<category>`** — in-shell help (CTRL+X+H). Update if any command behaviour, alias, keybinding, or output format changed.
+2. **`README.md` → `## Features`** — public reference. Must stay in sync with the help files (see "Dual-location documentation rule"). Update in the same commit as the code.
+3. **`CLAUDE.md`** — update if the session introduces new files, directories, env variables, architectural decisions, or constraints.
+4. **`KNOWN_ISSUES.md`** — remove an entry in the same commit that fixes the underlying bug. Add an entry for newly discovered confirmed-but-unfixed defects.
+5. **`CHANGELOG.md`** — when cutting a release, populate from `git log` since the last tag (see "Release process").
+
+### Dual-location documentation rule (enforced)
+
+Every command, alias, and keybinding mentioned in `README.md → ## Features` **must** appear in the corresponding `src/main/help/help_<category>` file, and vice versa. After any feature work, compare both locations and flag any discrepancy — do not close the task until they are in sync.
+
+> **Root cause of doc drift:** code is changed but only one location (or neither) is updated. The checklist above exists to prevent this. If you find yourself thinking "I'll update the docs later" — stop and update them now, in the same commit.
+
+---
+
 ## Project Overview
 Nixlper is a bash helper inspired by Total Commander for Unix/Linux environments. Provides keyboard-driven file navigation, bookmarks, macros, and process management.
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ and alias) so you can fuzzy-search and execute without remembering exact names.
 ### Navigation
 
 - `CTRL + X THEN U`: perform a "cd .."
-- `CTRL + X THEN N`: display an interactive way to navigate to subfolders and to open files with alias/copy-paste
+- `CTRL + X THEN N`: display an interactive way to navigate to subfolders and to open files with alias/copy-paste.
+  For each file, shortcuts to open (`vN`), cd into its folder and navigate (`cdfN`), or delete it (`dN`) are available.
   (Navigation can use tree or flat mode. "tree" is the default value and requires `tree`)
 
 See ```export NIXLPER_NAVIGATE_MODE=tree``` in ~/.bashrc.

--- a/src/main/help/help_navigation
+++ b/src/main/help/help_navigation
@@ -9,6 +9,7 @@ cdf FILEPATH : will go to the folder of the file
 [CTRL + X THEN N] display an interactive way to navigate to subfolders and to open files with alias/copy-paste using
 tree mode or flat mode.
 See NIXLPER_NAVIGATE_MODE in ~/.bashrc and use "flat" or "tree" value.
+For each file, shortcuts to open (vN), go to its folder (cdfN), or delete it (dN) are available.
 
 Tree mode
     ------------------------------------------------------------------------------------------------------------------------
@@ -18,7 +19,7 @@ Tree mode
     ├── item N (→ or ↓) SHORTCUT_COMMAND
     ├── ..
     └── last item (→ or ↓) SHORTCUT_COMMAND
-    HINT 1: use alias nNUMBER to navigate, alias vNUMBER to open a file (FILES AND FOLDERS/ALIAS MODE)
+    HINT 1: use alias nNUMBER to navigate, vNUMBER to open, cdfNUMBER to go to folder, dNUMBER to delete
     HINT 2: use CTRL + X, NUMBER to navigate (FOLDERS ONLY/BINDING MODE)
     -> Currently in /appli/install
     ------------------------------------------------------------------------------------------------------------------------
@@ -26,10 +27,10 @@ Tree mode
 Flat mode
     ------------------------------------------------------------------------------------------------------------------------
     Open..
-    vim file1 # (v1)
-    vim file2 # (v2)
+    vim file1 # (v1 | cdf1 | d1)
+    vim file2 # (v2 | cdf2 | d2)
     ..
-    vim fileN # (vN)
+    vim fileN # (vN | cdfN | dN)
     ----
     Go to subfolder
     navigate absolute_path_1 # (n1 / CTRL + X, 1)
@@ -41,7 +42,7 @@ Flat mode
     cd parent_folder # CTRL + X THEN U
     ------------------------------------------------------------------------------------------------------------------------
     HINT 1: double click then right click for copy/paste (FILES AND FOLDERS/MOUSE MODE)
-    HINT 2: use alias nNUMBER to navigate, alias vNUMBER to open a file (FILES AND FOLDERS/ALIAS MODE)
+    HINT 2: use alias nNUMBER to navigate, vNUMBER to open, cdfNUMBER to go to folder, dNUMBER to delete
     HINT 3: use CTRL + X, NUMBER to navigate (FOLDERS ONLY/BINDING MODE)
     -> Currently in current_folder"
     ------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Updated documentation to clarify the full set of shortcuts available in the interactive navigation mode (CTRL+X+N). Previously, only the `vN` (open file) shortcut was prominently mentioned; this change explicitly documents `cdfN` (go to folder) and `dN` (delete) shortcuts alongside it.

## Changes

- **`src/main/help/help_navigation`**
  - Added introductory line explaining all three shortcut types (vN, cdfN, dN) are available for each file
  - Updated HINT 1 in tree mode to list all three shortcuts instead of just vN
  - Updated flat mode examples to show all three shortcuts in comments (e.g., `# (v1 | cdf1 | d1)`)
  - Updated HINT 2 in flat mode to list all three shortcuts

- **`README.md`**
  - Expanded the `CTRL + X THEN N` feature description to explicitly mention cdfN and dN shortcuts
  - Formatted shortcuts with backticks for consistency

- **`CLAUDE.md`**
  - Added mandatory "Documentation Completeness" section with enforced checklist
  - Documented the "Dual-location documentation rule" to prevent doc drift between help files and README
  - Clarified that documentation updates must happen in the same commit as code changes

## Notes
This change follows the newly documented dual-location documentation rule: help file and README are now in sync regarding the navigation shortcuts feature.

https://claude.ai/code/session_01HQqdZXyttpCsyFDeFNPH72