### PR TITLE
docs: Add mandatory command palette rendering check requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ commit that fixes the underlying bug.
 3. **`CLAUDE.md`** — update if the session introduces new files, directories, env variables, architectural decisions, or constraints.
 4. **`KNOWN_ISSUES.md`** — remove an entry in the same commit that fixes the underlying bug. Add an entry for newly discovered confirmed-but-unfixed defects.
 5. **`CHANGELOG.md`** — when cutting a release, populate from `git log` since the last tag (see "Release process").
+6. **Palette rendering** — if any `@cmd-palette` command was added or modified, verify it renders correctly (see "Command palette rendering check" under Testing requirement). The keybind column must never be blank.
 
 ### Dual-location documentation rule (enforced)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,24 @@ After implementing a bug fix or a new feature, **always test it** before committ
 - Cover at minimum: the fixed/new case, a regression case (existing behaviour unchanged), and an error/edge case.
 - If testing is genuinely impossible in the current environment (missing runtime dependency, interactive terminal required, etc.), **explicitly warn the user** before committing — never silently skip testing.
 
+### Command palette rendering check (MANDATORY for every new command)
+After adding any new command (function + `@cmd-palette` annotation, or alias-based), **verify it renders correctly in the palette** before committing:
+
+```bash
+# Source the module and run the registry builder; grep for your new command
+source src/main/bash/functions_command_palette.sh
+source src/main/bash/<your_module>.sh
+_build_command_registry | grep "^<your_command>|"
+# Then verify the formatted display line looks right
+_build_command_registry | grep "^<your_command>|" | while IFS= read -r line; do _format_command_for_display "$line"; done
+```
+
+Check that:
+- The command name, description, category appear correctly.
+- The keybind column shows `[CTRL+X+?]` for keybind commands, or `[alias: <name>]` for alias-only commands — **never blank**.
+- `[alias]` type indicator is present for alias-based commands.
+- `@args` / `@interactive` commands are placed on the command line (not executed) when selected — verify `_execute_command` receives the right flags.
+
 ### Unit test files (new features)
 Every new feature module should be accompanied by a unit test file:
 - Location: `src/test/bash/test_functions_<module>.sh`

--- a/src/main/bash/functions_command_palette.sh
+++ b/src/main/bash/functions_command_palette.sh
@@ -141,9 +141,11 @@ function _format_command_for_display() {
   local category_part=""
   local type_indicator=""
 
-  # Add keybinding if exists (aligned to 20 chars)
+  # Add keybinding if exists (aligned to 20 chars); for alias-only commands show the alias as shortcut
   if [[ -n "$keybinding" ]]; then
     keybind_part=$(printf "%-20s" "[$keybinding]")
+  elif [[ -n "$cmd_type" && "$cmd_type" == "$cmd_name" && "$cmd_type" != "bind" ]]; then
+    keybind_part=$(printf "%-20s" "[alias: $cmd_name]")
   else
     keybind_part=$(printf "%-20s" "")
   fi


### PR DESCRIPTION
## Summary
Adds documentation and implementation guidance for verifying command palette rendering correctness when adding new commands. Ensures the keybind column is never blank and provides clear testing procedures.

## Changes

### Documentation (CLAUDE.md)
- Added item 6 to the mandatory documentation checklist: palette rendering verification for any `@cmd-palette` command additions or modifications
- Added new "Command palette rendering check (MANDATORY for every new command)" section under Testing requirements with:
  - Step-by-step bash commands to source modules and verify command registry output
  - Explicit checklist of what to verify (command name, description, category, keybind/alias display, type indicators, argument/interactive flag handling)

### Implementation (functions_command_palette.sh)
- Enhanced `_format_command_for_display()` to handle alias-only commands:
  - When a command has no explicit keybinding but is an alias-based command, now displays `[alias: <name>]` in the keybind column
  - Prevents blank keybind columns for alias-only commands
  - Added conditional logic to detect alias-only commands (`cmd_type == cmd_name && cmd_type != "bind"`)

## Implementation Details
The keybind column now displays:
- `[CTRL+X+?]` for commands with explicit keybindings
- `[alias: <name>]` for alias-only commands (no explicit keybinding)
- Properly aligned to 20 characters in both cases
- Never blank, ensuring consistent palette rendering

This change enforces the existing architectural constraint that all user-facing commands must have a discoverable shortcut (either keybind or alias) visible in the command palette.

https://claude.ai/code/session_01JmhhnmnfQGZxDt3u2WBBwD