### PR TITLE
🚀deploy|Release v2.1.0 with update channels and documentation updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [2.1.0] - 2026-06-10
+
 ### Added
 - **Update detection with channels** (`NIXLPER_UPDATE_CHANNEL`): `stable` tracks tagged
   releases and suggests an update when a newer tag exists; `edge` tracks the latest commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ commit that fixes the underlying bug.
 3. **`CLAUDE.md`** — update if the session introduces new files, directories, env variables, architectural decisions, or constraints.
 4. **`KNOWN_ISSUES.md`** — remove an entry in the same commit that fixes the underlying bug. Add an entry for newly discovered confirmed-but-unfixed defects.
 5. **`CHANGELOG.md`** — when cutting a release, populate from `git log` since the last tag (see "Release process").
-6. **Palette rendering** — if any `@cmd-palette` command was added or modified, verify it renders correctly (see "Command palette rendering check" under Testing requirement). The keybind column must never be blank.
+6. **Palette rendering** — if any `@cmd-palette` command was added or modified, verify it renders correctly (see "Command palette rendering check" under Testing requirement). A command with no `@keybind` or `@alias` may have a blank keybind column — that is acceptable. What is **never acceptable** is a command that *has* a keybind or alias defined but it does not appear in the palette column.
 
 ### Dual-location documentation rule (enforced)
 
@@ -263,7 +263,7 @@ _build_command_registry | grep "^<your_command>|" | while IFS= read -r line; do 
 
 Check that:
 - The command name, description, category appear correctly.
-- The keybind column shows `[CTRL+X+?]` for keybind commands, or `[alias: <name>]` for alias-only commands — **never blank**.
+- The keybind column shows `[CTRL+X+?]` for keybind commands, or `[alias: <name>]` for alias-only commands. A blank keybind column is **acceptable** when the command has no `@keybind` or `@alias`. It is **never acceptable** when a keybind or alias is defined but not displayed.
 - `[alias]` type indicator is present for alias-based commands.
 - `@args` / `@interactive` commands are placed on the command line (not executed) when selected — verify `_execute_command` receives the right flags.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # NIXLPER
 
-> 🚀 **Current version: v2.0.1** — [Release notes](https://github.com/Minhounet/nixlper/releases)
+> 🚀 **Current version: v2.1.0** — [Release notes](https://github.com/Minhounet/nixlper/releases)
 >
-> **What's new in v2.0.1:** Fixed command palette double-print after command execution and header border misalignment.
+> **What's new in v2.1.0:** Introduces update channels (stable/edge/off) with on-demand checks (`nu` / `CTRL+X+W`), opt-in auto-update, offline-safe probing, and `install.sh` channel selection.
 >
 > Nixlper evolves constantly. Tagged releases are stable snapshots. Two channels are available: **stable** (default, tagged releases) and **edge** (rolling build of every commit on `main`, not an official release). See [Updates](#updates) for installation commands.
 


### PR DESCRIPTION
## Summary
This PR cuts the v2.1.0 release, updating version references and documentation to reflect the new update channel feature (stable/edge/off) with on-demand checks and opt-in auto-update capability.

## Changes

- **Version bump**: Updated README.md and CHANGELOG.md to v2.1.0
- **Release notes**: Updated README.md with v2.1.0 feature summary (update channels, on-demand checks via `nu` / `CTRL+X+W`, opt-in auto-update, offline-safe probing, `install.sh` channel selection)
- **Documentation clarification**: Updated CLAUDE.md to clarify command palette keybind column rendering rules:
  - Commands with no `@keybind` or `@alias` may have blank keybind columns (acceptable)
  - Commands with defined keybinds/aliases **must** display them in the palette (never acceptable to omit)
- **Changelog entry**: Added v2.1.0 release section to CHANGELOG.md with date 2026-06-10

## Notes
All documentation updates follow the mandatory completeness checklist. The keybind column rendering clarification in CLAUDE.md reflects the actual behavior and testing requirements for the command palette feature.

https://claude.ai/code/session_01SYpoLbWmNMDtUaWq28RN8A