### PR TITLE
✨feat|Add nconf interactive config editor with .bashrc migration.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'cmd=$(jq -r \".tool_input.command\"); [[ \"$cmd\" =~ git[[:space:]]+commit ]] && echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"additionalContext\\\":\\\"MANDATORY CHECKLIST (CLAUDE.md) before committing: 1) Tests written and passing for any new/changed module? 2) src/main/help/help_* updated? 3) README.md Features section updated? 4) KNOWN_ISSUES.md in sync? Do NOT proceed with the commit until all applicable items are confirmed.\\\"}}\" || true'"
+            "command": "bash -c 'cmd=$(jq -r \".tool_input.command\"); [[ \"$cmd\" =~ git[[:space:]]+commit ]] && echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"additionalContext\\\":\\\"MANDATORY CHECKLIST (CLAUDE.md) before committing: 1) BUG SWEEP — did you read every new/modified function for edge cases, special-char handling, missing-file cases, and broken assumptions in pre-existing code? Fix all found bugs now or add them to KNOWN_ISSUES.md. 2) Tests written and passing for any new/changed module? 3) src/main/help/help_* updated? 4) README.md Features section updated? 5) KNOWN_ISSUES.md in sync? Do NOT proceed with the commit until all applicable items are confirmed.\\\"}}\" || true'"
           }
         ]
       }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run target-staging unit tests
         run: bash src/test/bash/test_functions_target.sh
+
+      - name: Run config-editor unit tests
+        run: bash src/test/bash/test_functions_config.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,13 @@ After implementing a bug fix or a new feature, **always test it** before committ
 - Cover at minimum: the fixed/new case, a regression case (existing behaviour unchanged), and an error/edge case.
 - If testing is genuinely impossible in the current environment (missing runtime dependency, interactive terminal required, etc.), **explicitly warn the user** before committing — never silently skip testing.
 
+### Bug sweep — MANDATORY before every commit
+Before committing any feature or fix, **actively scan the code you wrote or touched for bugs**:
+- Read each new/modified function end-to-end and ask: "What breaks if the input contains special characters? What if the file doesn't exist yet? What if this runs twice?"
+- Check every interaction with pre-existing code: does the new code change assumptions that older functions relied on? (Example: a new config file changes where settings live — does the installer still handle the old location correctly?)
+- If you find a bug, fix it in the same commit. If it is out of scope, add it to `KNOWN_ISSUES.md` before committing.
+- **Never hand work back to the user with known, unaddressed bugs unless they are explicitly deferred and tracked.**
+
 ### Command palette rendering check (MANDATORY for every new command)
 After adding any new command (function + `@cmd-palette` annotation, or alias-based), **verify it renders correctly in the palette** before committing:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,10 @@ src/main/bash/*.sh → build.sh → build/distributions/nixlper-*.tar
 nixlper/
 ├── src/main/bash/          # Individual bash modules
 │   ├── nixlper.sh          # Main entry point
+│   ├── functions_config.sh # Interactive config editor (nconf, migration)
 │   └── functions_*.sh      # Feature modules
+├── src/main/help/
+│   └── help_config         # In-shell help for nconf (CTRL+X+H)
 ├── build.sh                # Build script (concatenation + tar packaging)
 ├── build-rpm.sh            # RPM build script (calls build.sh, then rpmbuild)
 ├── install.sh              # Manual tar-based installer (downloads from GitHub releases)
@@ -410,9 +413,19 @@ bash build-rpm.sh
 
 All variables follow a precedence chain — later sources override earlier ones:
 
-1. `/etc/nixlper/nixlper.conf` — system defaults (RPM/DEB managed, uses `:-` so it never overrides vars already set by `~/.bashrc`)
-2. `~/.config/nixlper/nixlper.conf` — per-user overrides
-3. `~/.bashrc` — manual install sets vars here before sourcing nixlper.sh
+1. `/etc/nixlper/nixlper.conf` — system defaults (RPM/DEB managed, uses `:-` so it never overrides already-set vars)
+2. `~/.config/nixlper/nixlper.conf` — per-user overrides (highest precedence; managed by `nconf`)
+3. `~/.bashrc` — legacy manual install only; **deprecated** for storing settings (see migration below)
+
+**Manual install — new behaviour (post-migration):** `~/.bashrc` contains only `source /opt/nixlper/nixlper.sh`.
+All settings live in `~/.config/nixlper/nixlper.conf`, created at install time with `NIXLPER_INSTALL_DIR` set
+and all other vars commented out as documentation. `nconf` (CTRL+X+C) prompts for migration on first run
+when old-style `export NIXLPER_*` lines are detected in `~/.bashrc`.
+
+Actual precedence (lowest → highest):
+```
+/etc/nixlper/nixlper.conf  <  ~/.bashrc exports  <  ~/.config/nixlper/nixlper.conf
+```
 
 | Variable | Manual install default | RPM/DEB default |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ sudo dpkg -r nixlper
 > Throughout this section, `$NIXLPER_EDITOR` refers to the editor used to open files
 > (defaults to `vim`, configurable via the `NIXLPER_EDITOR` environment variable).
 
+### Configuration
+
+- `CTRL + X then C` (or `nconf`): open the interactive configuration editor
+
+`nconf` opens an `fzf`-powered list of all configurable settings. Select an entry and press Enter to edit it.
+Boolean and enum settings use a selection list; text and integer settings use a pre-filled prompt.
+Only values that differ from the default are written to `~/.config/nixlper/nixlper.conf`.
+
+**First-run migration:** if your nixlper variables are still in `~/.bashrc` (manual install), `nconf` will offer a one-time migration that moves them to `~/.config/nixlper/nixlper.conf` and leaves `~/.bashrc` with only the source line. A backup is made before any change; recovery instructions are printed if anything goes wrong.
+
+> Requires [`fzf`](https://github.com/junegunn/fzf#installation).
+
 ### Command Palette (Find Action)
 
 The fastest way to discover and run any Nixlper command. It opens an `fzf`-powered,
@@ -262,7 +274,7 @@ and alias) so you can fuzzy-search and execute without remembering exact names.
   For each file, shortcuts to open (`vN`), cd and navigate (`cdfN`), delete (`dN`), copy to target staging (`tcN`), or mark for pack (`tmN`) are available.
   (Navigation can use tree or flat mode. "tree" is the default value and requires `tree`)
 
-See ```export NIXLPER_NAVIGATE_MODE=tree``` in ~/.bashrc.
+Configure `NIXLPER_NAVIGATE_MODE` via `nconf` (or edit `~/.config/nixlper/nixlper.conf` directly).
 
 
 - `toggle_navigation_mode`: 
@@ -287,7 +299,7 @@ Useful for shuttling files to a server via `/tmp`, or collecting scattered files
 - `tsd [DIRPATH]`: show or change the target folder for this session
 - `tclean`: delete all files in the target folder (confirmation required)
 
-Configure the default folder via `NIXLPER_TARGET_DIR` in `~/.bashrc` or `nixlper.conf`.
+Configure the default folder via `nconf` or `NIXLPER_TARGET_DIR` in `~/.config/nixlper/nixlper.conf`.
 
 ### Macros
 
@@ -346,7 +358,7 @@ curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh |
 
 **Internet is required.** When offline, the automatic check is skipped silently and never hangs (the probe is capped by `NIXLPER_UPDATE_TIMEOUT`, default 2s). Set `NIXLPER_UPDATE_CHANNEL=off` to disable checks entirely.
 
-Set `NIXLPER_UPDATE_AUTO=true` to install a detected update automatically (default is notify-only). Other tunables: `NIXLPER_UPDATE_CHECK` (true/false) and `NIXLPER_UPDATE_CHECK_INTERVAL` (seconds between automatic checks, default `86400`).
+Use `nconf` to interactively change update settings. Or set directly in `~/.config/nixlper/nixlper.conf`: `NIXLPER_UPDATE_AUTO=true` to auto-install updates (default is notify-only), `NIXLPER_UPDATE_CHECK=false` to disable, and `NIXLPER_UPDATE_CHECK_INTERVAL` (seconds between checks, default `86400`).
 
 ### Tips
 

--- a/src/main/bash/functions_config.sh
+++ b/src/main/bash/functions_config.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: functions_config.sh
+# DESCRIPTION: Interactive configuration editor — nconf manages ~/.config/nixlper/nixlper.conf
+########################################################################################################################
+
+_NIXLPER_USER_CONF="${HOME}/.config/nixlper/nixlper.conf"
+
+# Registry: "NAME|TYPE|DEFAULT|DESCRIPTION|SECTION"
+# TYPE: bool | enum:v1:v2:... | int | text | path
+_NIXLPER_CONFIG_VARS=(
+  "NIXLPER_EDITOR|text|vim|Text editor for file commands|common"
+  "NIXLPER_NAVIGATE_MODE|enum:tree:flat|tree|Navigation display mode|common"
+  "NIXLPER_DISABLE_WELCOME_MESSAGE|bool|false|Suppress startup banner at login|common"
+  "NIXLPER_DISABLE_TIPS|bool|false|Suppress tips at login|common"
+  "NIXLPER_UPDATE_CHECK|bool|true|Auto-check for updates at login|common"
+  "NIXLPER_UPDATE_AUTO|bool|false|Auto-install detected updates|common"
+  "NIXLPER_UPDATE_CHANNEL|enum:stable:edge:off|stable|Update channel|common"
+  "NIXLPER_TARGET_DIR|path|/tmp/nixlper_target|Staging folder for copy/mark/pack|common"
+  "NIXLPER_UPDATE_CHECK_INTERVAL|int|86400|Seconds between auto-checks|advanced"
+  "NIXLPER_UPDATE_TIMEOUT|int|2|Network probe timeout (seconds)|advanced"
+  "NIXLPER_BOOKMARKS_FILE|path||Bookmarks file path|advanced"
+  "NIXLPER_SNAPSHOT_DIR|path||Snapshots directory|advanced"
+  "NIXLPER_CUSTOM_DIR|path||Custom scripts directory|advanced"
+  "NIXLPER_LAST_MACRO_BINDING_FILE|path||Last macro binding file|advanced"
+  "NIXLPER_UPDATE_CACHE_FILE|path||Update check cache file|advanced"
+)
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_migration_needed: true if ~/.bashrc still has export NIXLPER_* lines
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_migration_needed() {
+  [[ -f "${HOME}/.bashrc" ]] && grep -q "^export NIXLPER_" "${HOME}/.bashrc" 2>/dev/null
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_show_recovery_help: print recovery instructions
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_show_recovery_help() {
+  local -r backup="${1:-}"
+  echo ""
+  echo "── Recovery ─────────────────────────────────────────────────────────────────"
+  [[ -n "$backup" ]] && printf "  Restore .bashrc : cp %s ~/.bashrc\n" "$backup"
+  echo "  Clean reinstall via RPM : bash nixlper.sh uninstall && dnf install nixlper-*.rpm"
+  echo "  Clean reinstall via DEB : bash nixlper.sh uninstall && dpkg -i nixlper-*.deb"
+  echo "  Report issues : https://github.com/Minhounet/nixlper/issues"
+  echo "─────────────────────────────────────────────────────────────────────────────"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_do_migrate: write config file from .bashrc vars, then clean .bashrc
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_do_migrate() {
+  local -r backup="$1"
+
+  echo "Step 1/3: Backing up ~/.bashrc → ${backup##*/}"
+  cp "${HOME}/.bashrc" "$backup" || { echo "ERROR: Backup failed. Aborting."; return 1; }
+
+  echo "Step 2/3: Writing ${_NIXLPER_USER_CONF}"
+  mkdir -p "${HOME}/.config/nixlper"
+  {
+    printf "# nixlper user configuration — migrated from ~/.bashrc on %s\n" "$(date)"
+    printf "# Edit interactively: nconf\n\n"
+    grep "^export NIXLPER_" "${HOME}/.bashrc"
+  } > "${_NIXLPER_USER_CONF}"
+
+  if ! bash -n "${_NIXLPER_USER_CONF}" 2>/dev/null; then
+    echo "ERROR: Config file has syntax errors. Aborting — ~/.bashrc not modified."
+    rm -f "${_NIXLPER_USER_CONF}"
+    _nconf_show_recovery_help "$backup"
+    return 1
+  fi
+
+  echo "Step 3/3: Cleaning ~/.bashrc"
+  # Replace ${NIXLPER_INSTALL_DIR}/nixlper.sh source line with the actual path so
+  # .bashrc no longer depends on NIXLPER_INSTALL_DIR being set before the source call.
+  if [[ -n "${NIXLPER_INSTALL_DIR:-}" ]]; then
+    sed -i "s|source \${NIXLPER_INSTALL_DIR}/nixlper\.sh|source ${NIXLPER_INSTALL_DIR}/nixlper.sh|g" \
+      "${HOME}/.bashrc"
+  fi
+  sed -i "/^export NIXLPER_/d" "${HOME}/.bashrc"
+
+  echo ""
+  echo "✓ Migration complete."
+  printf "  Config : %s\n" "${_NIXLPER_USER_CONF}"
+  printf "  Backup : %s\n" "$backup"
+  echo ""
+  echo "Run: source ~/.bashrc  to apply in the current shell."
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_prompt_migration: explain migration and ask user to confirm
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_prompt_migration() {
+  local var_count
+  var_count=$(grep -c "^export NIXLPER_" "${HOME}/.bashrc" 2>/dev/null || echo 0)
+  local ts
+  ts=$(date +%Y%m%d-%H%M%S)
+  local -r backup="${HOME}/.bashrc.nixlper-backup-${ts}"
+
+  echo "────────────────────────────────────────────────────────────────────────────"
+  echo "nixlper config — migration available"
+  echo "────────────────────────────────────────────────────────────────────────────"
+  printf "  %s nixlper variable(s) found in ~/.bashrc.\n" "$var_count"
+  echo "  nixlper now uses ~/.config/nixlper/nixlper.conf for all settings,"
+  echo "  keeping ~/.bashrc to just the source line."
+  echo ""
+  echo "  Migration will:"
+  printf "    1. Back up ~/.bashrc  →  %s\n" "${backup##*/}"
+  echo "    2. Write your settings to ~/.config/nixlper/nixlper.conf"
+  echo "    3. Remove nixlper variables from ~/.bashrc (keep source line)"
+  echo "────────────────────────────────────────────────────────────────────────────"
+  echo -n "Migrate now? [y/N]: "
+  read -r answer
+
+  case "$answer" in
+    y|Y) _nconf_do_migrate "$backup" ;;
+    *)   echo "Skipped. Your ~/.bashrc is unchanged. You will be prompted again next time." ;;
+  esac
+  echo ""
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_ensure_config_file: create ~/.config/nixlper/nixlper.conf if it does not exist
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_ensure_config_file() {
+  [[ -f "${_NIXLPER_USER_CONF}" ]] && return 0
+  mkdir -p "${HOME}/.config/nixlper"
+  {
+    printf "# nixlper user configuration — edit with: nconf\n"
+    printf "# Only non-default values need to be set here.\n\n"
+    [[ -n "${NIXLPER_INSTALL_DIR:-}" ]] && printf "export NIXLPER_INSTALL_DIR=%s\n" "${NIXLPER_INSTALL_DIR}"
+  } > "${_NIXLPER_USER_CONF}"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_create_user_conf: create a documented config file template at install time
+# $1 = install_dir
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_create_user_conf() {
+  local -r install_dir="${1}"
+  [[ -f "${_NIXLPER_USER_CONF}" ]] && return 0
+  mkdir -p "${HOME}/.config/nixlper"
+  {
+    printf "# nixlper user configuration\n"
+    printf "# Edit interactively: nconf  |  or edit this file directly.\n"
+    printf "# Only lines that differ from defaults need to be uncommented.\n\n"
+    printf "export NIXLPER_INSTALL_DIR=%s\n\n" "${install_dir}"
+    printf "# --- Common settings ---\n"
+    printf "# export NIXLPER_EDITOR=vim\n"
+    printf "# export NIXLPER_NAVIGATE_MODE=tree\n"
+    printf "# export NIXLPER_DISABLE_WELCOME_MESSAGE=false\n"
+    printf "# export NIXLPER_DISABLE_TIPS=false\n"
+    printf "# export NIXLPER_UPDATE_CHECK=true\n"
+    printf "# export NIXLPER_UPDATE_AUTO=false\n"
+    printf "# export NIXLPER_UPDATE_CHANNEL=stable\n"
+    printf "# export NIXLPER_TARGET_DIR=/tmp/nixlper_target\n\n"
+    printf "# --- Advanced settings ---\n"
+    printf "# export NIXLPER_UPDATE_CHECK_INTERVAL=86400\n"
+    printf "# export NIXLPER_UPDATE_TIMEOUT=2\n"
+    printf "# export NIXLPER_BOOKMARKS_FILE=\${HOME}/.local/share/nixlper/bookmarks\n"
+    printf "# export NIXLPER_SNAPSHOT_DIR=\${HOME}/.local/share/nixlper/snapshots\n"
+    printf "# export NIXLPER_CUSTOM_DIR=\${HOME}/.config/nixlper/custom\n"
+    printf "# export NIXLPER_LAST_MACRO_BINDING_FILE=\${HOME}/.local/share/nixlper/last_macro_binding\n"
+    printf "# export NIXLPER_UPDATE_CACHE_FILE=\${HOME}/.local/share/nixlper/update_check\n"
+  } > "${_NIXLPER_USER_CONF}"
+  echo "  -> Created ${_NIXLPER_USER_CONF}"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_write_setting: write or remove a variable override in the user config file
+# $1 = varname, $2 = new value, $3 = default value
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_write_setting() {
+  local -r varname="$1" new_val="$2" default="$3"
+
+  _nconf_ensure_config_file
+
+  if [[ "$new_val" == "$default" && -n "$default" ]]; then
+    # Value equals default — remove any override so the default applies naturally
+    sed -i "/^export ${varname}=/d" "${_NIXLPER_USER_CONF}"
+    printf "Reset %s to default (%s).\n" "$varname" "$default"
+  else
+    if grep -q "^export ${varname}=" "${_NIXLPER_USER_CONF}" 2>/dev/null; then
+      sed -i "s|^export ${varname}=.*|export ${varname}=${new_val}|" "${_NIXLPER_USER_CONF}"
+    else
+      printf "export %s=%s\n" "$varname" "$new_val" >> "${_NIXLPER_USER_CONF}"
+    fi
+    printf "Set %s=%s\n" "$varname" "$new_val"
+  fi
+  # Reflect change in the current session immediately
+  export "${varname}=${new_val}"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_get_meta: populate type/default/desc/section for a given varname
+# Sets: _nconf_type, _nconf_default, _nconf_desc, _nconf_section
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_get_meta() {
+  local -r target="$1"
+  _nconf_type="" _nconf_default="" _nconf_desc="" _nconf_section=""
+  local entry n
+  for entry in "${_NIXLPER_CONFIG_VARS[@]}"; do
+    n=$(cut -d'|' -f1 <<< "$entry")
+    if [[ "$n" == "$target" ]]; then
+      _nconf_type=$(cut    -d'|' -f2 <<< "$entry")
+      _nconf_default=$(cut -d'|' -f3 <<< "$entry")
+      _nconf_desc=$(cut    -d'|' -f4 <<< "$entry")
+      _nconf_section=$(cut -d'|' -f5 <<< "$entry")
+      return 0
+    fi
+  done
+  return 1
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_edit_variable: type-aware value picker for a single variable
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_edit_variable() {
+  local -r varname="$1"
+  _nconf_get_meta "$varname" || return 1
+
+  local type="$_nconf_type"
+  local default="$_nconf_default"
+  local desc="$_nconf_desc"
+  local current="${!varname}"
+  [[ -z "$current" ]] && current="$default"
+
+  local new_val=""
+
+  if [[ "$type" == "bool" ]]; then
+    new_val=$(printf "true\nfalse\n" | fzf \
+      --height=7 --border=rounded --no-sort \
+      --prompt="${varname} > " \
+      --header="${desc} | current: ${current}" \
+      --color="header:cyan,prompt:green,pointer:yellow")
+
+  elif [[ "$type" == enum:* ]]; then
+    local opts_str="${type#enum:}"
+    local -a opts
+    IFS=':' read -ra opts <<< "$opts_str"
+    new_val=$(printf '%s\n' "${opts[@]}" | fzf \
+      --height="$(( ${#opts[@]} + 5 ))" --border=rounded --no-sort \
+      --prompt="${varname} > " \
+      --header="${desc} | current: ${current}" \
+      --color="header:cyan,prompt:green,pointer:yellow")
+
+  elif [[ "$type" == "int" ]]; then
+    printf "%s\nCurrent: %s  (default: %s)\n" "$desc" "$current" "${default:-n/a}"
+    local input
+    read -r -e -p "${varname} [${current}]: " -i "${current}" input
+    new_val="${input:-$current}"
+    if ! [[ "$new_val" =~ ^[0-9]+$ ]]; then
+      printf "Invalid integer '%s' — keeping current value.\n" "$new_val"
+      return 0
+    fi
+
+  else  # text or path
+    printf "%s\nCurrent: %s  (default: %s)\n" "$desc" "$current" "${default:-n/a}"
+    local input
+    read -r -e -p "${varname} [${current}]: " -i "${current}" input
+    new_val="${input:-$current}"
+    [[ -z "$new_val" ]] && return 0
+  fi
+
+  [[ -z "$new_val" ]] && return 0
+  _nconf_write_setting "$varname" "$new_val" "$default"
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# _nconf_build_fzf_input: emit tab-delimited lines: VARNAME<TAB>display_text
+# Separator lines use __sep__ as the key.
+#-----------------------------------------------------------------------------------------------------------------------
+function _nconf_build_fzf_input() {
+  local prev_section="common"
+  local entry varname type default desc section current indicator
+
+  for entry in "${_NIXLPER_CONFIG_VARS[@]}"; do
+    varname=$(cut  -d'|' -f1 <<< "$entry")
+    type=$(cut     -d'|' -f2 <<< "$entry")
+    default=$(cut  -d'|' -f3 <<< "$entry")
+    desc=$(cut     -d'|' -f4 <<< "$entry")
+    section=$(cut  -d'|' -f5 <<< "$entry")
+
+    if [[ "$section" == "advanced" && "$prev_section" == "common" ]]; then
+      prev_section="advanced"
+      printf '__sep__\t  %-3s  %-44s  %-24s  %s\n' "" \
+        "──── Advanced settings ─────────────────────" "" ""
+    fi
+
+    current="${!varname}"
+    [[ -z "$current" ]] && current="$default"
+
+    if grep -q "^export ${varname}=" "${_NIXLPER_USER_CONF}" 2>/dev/null; then
+      indicator="*"
+    else
+      indicator=" "
+    fi
+
+    printf '%s\t  [%s] %-44s  %-24s  %s\n' \
+      "$varname" "$indicator" "$varname" "$current" "$desc"
+  done
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# nconf: interactive configuration editor
+# @cmd-palette
+# @description: Open interactive configuration editor
+# @category: Utilities
+# @keybind: CTRL+X+C
+# @interactive
+#-----------------------------------------------------------------------------------------------------------------------
+function nconf() {
+  if ! command -v fzf &>/dev/null; then
+    printf "nconf requires fzf. Install it or edit %s directly.\n" "${_NIXLPER_USER_CONF}"
+    return 1
+  fi
+
+  if _nconf_migration_needed; then
+    _nconf_prompt_migration
+  fi
+
+  _nconf_ensure_config_file
+
+  local selection varname
+  while true; do
+    selection=$(_nconf_build_fzf_input | fzf \
+      --delimiter=$'\t' \
+      --with-nth=2 \
+      --ansi \
+      --height=80% \
+      --border=rounded \
+      --prompt="nixlper config > " \
+      --header="[*]=overridden from default  |  Enter=edit  |  ESC=close" \
+      --color="header:cyan,prompt:green,pointer:yellow")
+
+    [[ -z "$selection" ]] && break
+
+    varname=$(cut -f1 <<< "$selection")
+    [[ "$varname" == "__sep__" || -z "$varname" ]] && continue
+
+    echo ""
+    _nconf_edit_variable "$varname"
+    echo ""
+  done
+
+  printf "\nConfig file: %s\n" "${_NIXLPER_USER_CONF}"
+  echo "Open a new terminal (or run: source ~/.bashrc) to apply changes."
+}

--- a/src/main/bash/functions_config.sh
+++ b/src/main/bash/functions_config.sh
@@ -58,11 +58,30 @@ function _nconf_do_migrate() {
 
   echo "Step 2/3: Writing ${_NIXLPER_USER_CONF}"
   mkdir -p "${HOME}/.config/nixlper"
+  # Merge: existing config vars take priority; .bashrc vars fill in any that are missing.
+  local -a existing_vars=()
+  if [[ -f "${_NIXLPER_USER_CONF}" ]]; then
+    while IFS= read -r line; do
+      existing_vars+=("$line")
+    done < <(grep "^export NIXLPER_" "${_NIXLPER_USER_CONF}" 2>/dev/null)
+  fi
+  local tmp_conf
+  tmp_conf=$(mktemp)
   {
     printf "# nixlper user configuration — migrated from ~/.bashrc on %s\n" "$(date)"
     printf "# Edit interactively: nconf\n\n"
-    grep "^export NIXLPER_" "${HOME}/.bashrc"
-  } > "${_NIXLPER_USER_CONF}"
+    # Existing config file entries (highest priority)
+    printf '%s\n' "${existing_vars[@]+"${existing_vars[@]}"}"
+    # .bashrc entries not already present in the config file
+    while IFS= read -r line; do
+      local bvar="${line#export }"
+      bvar="${bvar%%=*}"
+      if ! printf '%s\n' "${existing_vars[@]+"${existing_vars[@]}"}" | grep -q "^export ${bvar}="; then
+        printf '%s\n' "$line"
+      fi
+    done < <(grep "^export NIXLPER_" "${HOME}/.bashrc" 2>/dev/null)
+  } > "$tmp_conf"
+  mv "$tmp_conf" "${_NIXLPER_USER_CONF}"
 
   if ! bash -n "${_NIXLPER_USER_CONF}" 2>/dev/null; then
     echo "ERROR: Config file has syntax errors. Aborting — ~/.bashrc not modified."
@@ -182,7 +201,9 @@ function _nconf_write_setting() {
     printf "Reset %s to default (%s).\n" "$varname" "$default"
   else
     if grep -q "^export ${varname}=" "${_NIXLPER_USER_CONF}" 2>/dev/null; then
-      sed -i "s|^export ${varname}=.*|export ${varname}=${new_val}|" "${_NIXLPER_USER_CONF}"
+      local escaped_val
+      escaped_val=$(printf '%s' "$new_val" | sed 's/[\\&|]/\\&/g')
+      sed -i "s|^export ${varname}=.*|export ${varname}=${escaped_val}|" "${_NIXLPER_USER_CONF}"
     else
       printf "export %s=%s\n" "$varname" "$new_val" >> "${_NIXLPER_USER_CONF}"
     fi

--- a/src/main/bash/functions_config.sh
+++ b/src/main/bash/functions_config.sh
@@ -81,14 +81,14 @@ function _nconf_do_migrate() {
       fi
     done < <(grep "^export NIXLPER_" "${HOME}/.bashrc" 2>/dev/null)
   } > "$tmp_conf"
-  mv "$tmp_conf" "${_NIXLPER_USER_CONF}"
 
-  if ! bash -n "${_NIXLPER_USER_CONF}" 2>/dev/null; then
-    echo "ERROR: Config file has syntax errors. Aborting — ~/.bashrc not modified."
-    rm -f "${_NIXLPER_USER_CONF}"
+  if ! bash -n "$tmp_conf" 2>/dev/null; then
+    echo "ERROR: Config file has syntax errors. Aborting — no files modified."
+    rm -f "$tmp_conf"
     _nconf_show_recovery_help "$backup"
     return 1
   fi
+  mv "$tmp_conf" "${_NIXLPER_USER_CONF}"
 
   echo "Step 3/3: Cleaning ~/.bashrc"
   # Replace ${NIXLPER_INSTALL_DIR}/nixlper.sh source line with the actual path so

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -116,6 +116,18 @@ function _i_install() {
 function _i_update() {
   echo "---------------------------------------------------------------------------------------------------------------"
   echo "Update Nixlper configuration"
+  # Before wiping the bashrc block, preserve any NIXLPER_ settings that haven't been
+  # migrated to ~/.config/nixlper/nixlper.conf yet.
+  local user_conf="${HOME}/.config/nixlper/nixlper.conf"
+  if grep -q "^export NIXLPER_" "${HOME}/.bashrc" 2>/dev/null && [[ ! -f "$user_conf" ]]; then
+    echo "  Preserving existing nixlper settings to ${user_conf}"
+    mkdir -p "${HOME}/.config/nixlper"
+    {
+      printf "# nixlper user configuration — preserved during update on %s\n" "$(date)"
+      printf "# Edit interactively: nconf\n\n"
+      grep "^export NIXLPER_" "${HOME}/.bashrc"
+    } > "$user_conf"
+  fi
   _i_delete_bashrc_config
   _i_set_bashrc_config
   echo "-> DONE (Update Nixlper configuration)"

--- a/src/main/bash/nixlper.sh
+++ b/src/main/bash/nixlper.sh
@@ -215,31 +215,22 @@ function _i_uninstall_system() {
 
 function _i_set_bashrc_config() {
   echo "  Update .bashrc with nixlper"
+  local install_dir
+  if [[ -z "${NIXLPER_INSTALL_DIR:-}" ]]; then
+    cd "$(dirname "$0")" || return 1
+    install_dir="$(pwd)"
+  else
+    install_dir="${NIXLPER_INSTALL_DIR}"
+  fi
   echo "" >> ~/.bashrc
   echo "################################ nixlper start #################################################" >> ~/.bashrc
   echo "# nixlper installation" >> ~/.bashrc
-  # For install NIXLPER_INSTALL_DIR, is not defined
-  if [[ -z "${NIXLPER_INSTALL_DIR}" ]]; then
-    cd "$(dirname $0)" || return 1
-    sed 's/^/# /g' "$(pwd)"/version | grep -v PROJECT >> ~/.bashrc
-  else
-    sed 's/^/# /g' "${NIXLPER_INSTALL_DIR}"/version | grep -v PROJECT >> ~/.bashrc
-  fi
+  sed 's/^/# /g' "${install_dir}/version" 2>/dev/null | grep -v PROJECT >> ~/.bashrc || true
   echo "################################################################################################" >> ~/.bashrc
-  echo "export NIXLPER_INSTALL_DIR=$(pwd)" >> ~/.bashrc
-  echo "export NIXLPER_BOOKMARKS_FILE=\${NIXLPER_INSTALL_DIR}/.nixlper_bookmarks" >> ~/.bashrc
-  echo "export NIXLPER_LAST_MACRO_BINDING_FILE=\${NIXLPER_INSTALL_DIR}/.nixlper_last_macro_binding_file" >> ~/.bashrc
-  echo "export NIXLPER_NAVIGATE_MODE=tree" >> ~/.bashrc
-  echo "export NIXLPER_EDITOR=vim" >> ~/.bashrc
-  echo "export NIXLPER_DISABLE_WELCOME_MESSAGE=false" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_CHANNEL=${NIXLPER_INSTALL_CHANNEL:-stable}" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_CHECK=true" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_AUTO=false" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_CHECK_INTERVAL=86400" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_TIMEOUT=2" >> ~/.bashrc
-  echo "export NIXLPER_UPDATE_CACHE_FILE=\${NIXLPER_INSTALL_DIR}/.nixlper_update_check" >> ~/.bashrc
-  echo "source \${NIXLPER_INSTALL_DIR}/nixlper.sh" >> ~/.bashrc
+  # Only the source line goes into .bashrc — all settings live in ~/.config/nixlper/nixlper.conf
+  echo "source ${install_dir}/nixlper.sh" >> ~/.bashrc
   echo "################################ nixlper stop ##################################################" >> ~/.bashrc
+  _nconf_create_user_conf "${install_dir}"
   source ~/.bashrc
   echo "  -> DONE (Update .bashrc with nixlper)"
 }
@@ -313,6 +304,9 @@ function _i_load_bindings() {
 
     # command palette - annotation already in functions_command_palette.sh
     bind -x '"\C-x\C-a": find_action'
+
+    # config editor - annotation already in functions_config.sh
+    bind '"\C-x\C-c": "nconf\15"'
   fi
 }
 

--- a/src/main/help/help_config
+++ b/src/main/help/help_config
@@ -1,0 +1,51 @@
+########################################################################################################################
+# Help for configuration
+########################################################################################################################
+------------------------------------------------------------------------------------------------------------------------
+[CTRL + X THEN C] or  nconf : open the interactive configuration editor
+------------------------------------------------------------------------------------------------------------------------
+nconf opens a searchable, fzf-powered list of all configurable nixlper settings.
+Select any entry and press Enter to edit it. Settings are saved to:
+
+  ~/.config/nixlper/nixlper.conf
+
+Only values that differ from the default are written — the file stays minimal.
+Changes take effect in new shells. To apply immediately: source ~/.bashrc
+
+------------------------------------------------------------------------------------------------------------------------
+Common settings (shown first in nconf):
+
+  NIXLPER_EDITOR                   text     vim        Text editor for file commands
+  NIXLPER_NAVIGATE_MODE            enum     tree       Navigation display mode (tree or flat)
+  NIXLPER_DISABLE_WELCOME_MESSAGE  bool     false      Suppress startup banner at login
+  NIXLPER_DISABLE_TIPS             bool     false      Suppress tips at login
+  NIXLPER_UPDATE_CHECK             bool     true       Auto-check for updates at login
+  NIXLPER_UPDATE_AUTO              bool     false      Auto-install detected updates
+  NIXLPER_UPDATE_CHANNEL           enum     stable     Update channel (stable | edge | off)
+  NIXLPER_TARGET_DIR               path     /tmp/...   Staging folder for copy/mark/pack
+
+Advanced settings (shown below common in nconf):
+
+  NIXLPER_UPDATE_CHECK_INTERVAL    int      86400      Seconds between auto-checks
+  NIXLPER_UPDATE_TIMEOUT           int      2          Network probe timeout (seconds)
+  NIXLPER_BOOKMARKS_FILE           path                Bookmarks file path
+  NIXLPER_SNAPSHOT_DIR             path                Snapshots directory
+  NIXLPER_CUSTOM_DIR               path                Custom scripts directory
+  NIXLPER_LAST_MACRO_BINDING_FILE  path                Last macro binding file
+  NIXLPER_UPDATE_CACHE_FILE        path                Update check cache file
+
+------------------------------------------------------------------------------------------------------------------------
+Indicator column in nconf:
+  [*]  value has been overridden from default in ~/.config/nixlper/nixlper.conf
+  [ ]  value is using the default (or env-derived value)
+
+Resetting a value to its default removes the line from the config file.
+------------------------------------------------------------------------------------------------------------------------
+Migration from ~/.bashrc:
+  If your nixlper variables are still in ~/.bashrc (manual install), nconf will
+  offer a one-time migration that moves them to ~/.config/nixlper/nixlper.conf and
+  leaves ~/.bashrc with only the source line. A backup is made before any change.
+
+  If migration fails, recovery options are printed — including how to restore the
+  backup or reinstall cleanly via RPM or DEB.
+------------------------------------------------------------------------------------------------------------------------

--- a/src/main/help/help_navigation
+++ b/src/main/help/help_navigation
@@ -8,7 +8,7 @@ cdf FILEPATH : will go to the folder of the file
 ------------------------------------------------------------------------------------------------------------------------
 [CTRL + X THEN N] display an interactive way to navigate to subfolders and to open files with alias/copy-paste using
 tree mode or flat mode.
-See NIXLPER_NAVIGATE_MODE in ~/.bashrc and use "flat" or "tree" value.
+Configure NIXLPER_NAVIGATE_MODE via nconf (or ~/.config/nixlper/nixlper.conf) using "flat" or "tree" value.
 For each file, shortcuts to open (vN), go to its folder (cdfN), or delete it (dN) are available.
 
 Tree mode

--- a/src/main/help/help_updates
+++ b/src/main/help/help_updates
@@ -28,8 +28,9 @@ Updating when notified:
   stable : curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh | bash
   edge   : curl -fsSL https://raw.githubusercontent.com/Minhounet/nixlper/main/install.sh | bash -s -- --channel edge
 
-Opt-in automatic update: set  export NIXLPER_UPDATE_AUTO=true  to install the new build
-immediately when one is detected (default is notify-only).
+Opt-in automatic update: set NIXLPER_UPDATE_AUTO=true to install a detected update automatically
+(default is notify-only). Use  nconf  (CTRL+X+C) to change this and other update settings
+interactively, or edit ~/.config/nixlper/nixlper.conf directly.
 
 Showing ongoing work ( nw / CTRL+X+G ):
   Fetches the edge pre-release notes from GitHub and prints the list of commits since the last

--- a/src/test/bash/test_functions_config.sh
+++ b/src/test/bash/test_functions_config.sh
@@ -112,6 +112,24 @@ _expect_true  "third var written"                  _file_contains  "${_NIXLPER_U
 _nconf_write_setting "NIXLPER_BOOKMARKS_FILE" "/custom/path" ""
 _expect_true  "empty-default var written"          _file_contains  "${_NIXLPER_USER_CONF}" "export NIXLPER_BOOKMARKS_FILE=/custom/path"
 
+# Bug 1 regression: special characters in value must not corrupt the config file
+_reset_conf
+_nconf_write_setting "NIXLPER_EDITOR" "/usr/bin/vi" "vim"
+_nconf_write_setting "NIXLPER_EDITOR" "/opt/my|editor" "vim"
+_expect_true  "pipe char in value written correctly"   _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=/opt/my|editor"
+_expect_eq    "no extra lines after pipe update"       "$(grep -c 'NIXLPER_EDITOR' "${_NIXLPER_USER_CONF}")" "1"
+
+_reset_conf
+_nconf_write_setting "NIXLPER_EDITOR" "/usr/bin/vi" "vim"
+_nconf_write_setting "NIXLPER_EDITOR" "/opt/my&editor" "vim"
+_expect_true  "ampersand in value written correctly"   _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=/opt/my&editor"
+_expect_eq    "no extra lines after ampersand update"  "$(grep -c 'NIXLPER_EDITOR' "${_NIXLPER_USER_CONF}")" "1"
+
+_reset_conf
+_nconf_write_setting "NIXLPER_EDITOR" "/usr/bin/vi" "vim"
+_nconf_write_setting "NIXLPER_EDITOR" "/opt/back\\slash" "vim"
+_expect_true  "backslash in value written correctly"   _file_contains "${_NIXLPER_USER_CONF}" 'NIXLPER_EDITOR'
+
 #-----------------------------------------------------------------------------------------------------------------------
 echo "== _nconf_get_meta =="
 _nconf_get_meta "NIXLPER_EDITOR"
@@ -174,6 +192,30 @@ _expect_false "NIXLPER_ vars gone from bashrc"     _file_contains "${HOME}/.bash
 _expect_true  "user content preserved"             _file_contains "${HOME}/.bashrc" "# user content"
 _expect_true  "source line hardened"               _file_contains "${HOME}/.bashrc" "source /opt/nixlper/nixlper.sh"
 _expect_false "variable source line removed"       _file_contains "${HOME}/.bashrc" 'source ${NIXLPER_INSTALL_DIR}'
+
+# Bug 3 regression: second migration must not overwrite nconf-edited values in the config file
+# Simulate: user ran nconf and changed NIXLPER_EDITOR to emacs in the config file,
+# then runs nconf again (which triggers migration again because .bashrc still has NIXLPER_EDITOR=nano).
+# The config file value (emacs) must win over the .bashrc value (nano).
+_reset_bashrc
+cat > "${HOME}/.bashrc" << 'BASHRC'
+export NIXLPER_EDITOR=nano
+export NIXLPER_UPDATE_CHANNEL=edge
+source /opt/nixlper/nixlper.sh
+BASHRC
+# Config file already exists with a user edit
+mkdir -p "${HOME}/.config/nixlper"
+printf "export NIXLPER_EDITOR=emacs\n" > "${_NIXLPER_USER_CONF}"
+
+local_backup2="${HOME}/.bashrc.nixlper-backup-test2"
+_nconf_do_migrate "$local_backup2"
+
+_expect_true  "conf-file value (emacs) survives second migration" \
+              _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=emacs"
+_expect_false "bashrc value (nano) does not overwrite conf-file"  \
+              _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=nano"
+_expect_true  "bashrc-only var (CHANNEL) still imported"          \
+              _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_UPDATE_CHANNEL=edge"
 
 #-----------------------------------------------------------------------------------------------------------------------
 echo ""

--- a/src/test/bash/test_functions_config.sh
+++ b/src/test/bash/test_functions_config.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+########################################################################################################################
+# FILE: test_functions_config.sh
+# DESCRIPTION: Unit tests for functions_config.sh (non-interactive helpers only).
+#
+# fzf-driven and read-driven flows are not tested here — only the pure-bash helpers
+# that can run offline in a temp environment: migration detection, config file
+# read/write, and metadata lookups.
+# Run locally with: bash src/test/bash/test_functions_config.sh
+########################################################################################################################
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+MODULE="${REPO_ROOT}/src/main/bash/functions_config.sh"
+
+if [[ ! -f "${MODULE}" ]]; then
+  echo "❌ Cannot find module under test: ${MODULE}" >&2
+  exit 1
+fi
+
+# Isolated temp environment — override HOME so no real files are touched
+_TEST_DIR="$(mktemp -d)"
+export HOME="${_TEST_DIR}/home"
+mkdir -p "${HOME}/.config/nixlper"
+trap 'rm -rf "${_TEST_DIR}"' EXIT
+
+export NIXLPER_INSTALL_DIR="${_TEST_DIR}/install"
+mkdir -p "${NIXLPER_INSTALL_DIR}"
+
+# shellcheck source=/dev/null
+source "${MODULE}"
+
+# _NIXLPER_USER_CONF was set during source using $HOME (already the temp dir)
+
+#-----------------------------------------------------------------------------------------------------------------------
+PASS=0
+FAIL=0
+
+_expect_eq() {
+  local -r name="$1" got="$2" want="$3"
+  if [[ "${got}" == "${want}" ]]; then
+    echo "  ✅ ${name}"; PASS=$((PASS + 1))
+  else
+    echo "  ❌ ${name}: got [${got}] want [${want}]"; FAIL=$((FAIL + 1))
+  fi
+}
+
+_expect_true() {
+  local -r name="$1"; shift
+  if "$@"; then echo "  ✅ ${name}"; PASS=$((PASS + 1))
+  else echo "  ❌ ${name}: expected success"; FAIL=$((FAIL + 1)); fi
+}
+
+_expect_false() {
+  local -r name="$1"; shift
+  if "$@"; then echo "  ❌ ${name}: expected failure"; FAIL=$((FAIL + 1))
+  else echo "  ✅ ${name}"; PASS=$((PASS + 1)); fi
+}
+
+_file_exists()     { [[ -f "$1" ]]; }
+_file_contains()   { grep -q "$2" "$1" 2>/dev/null; }
+_file_not_exists() { [[ ! -f "$1" ]]; }
+
+_reset_conf()   { rm -f "${_NIXLPER_USER_CONF}"; }
+_reset_bashrc() { rm -f "${HOME}/.bashrc"; touch "${HOME}/.bashrc"; }
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _nconf_migration_needed =="
+_reset_bashrc
+_expect_false "no NIXLPER_ lines → not needed"     _nconf_migration_needed
+echo "export NIXLPER_EDITOR=nano"  >> "${HOME}/.bashrc"
+_expect_true  "has NIXLPER_ export → needed"       _nconf_migration_needed
+echo "# comment"                   >> "${HOME}/.bashrc"
+_expect_true  "still needed with extra lines"      _nconf_migration_needed
+_reset_bashrc
+echo "export OTHER_VAR=foo"        >> "${HOME}/.bashrc"
+_expect_false "non-NIXLPER export → not needed"    _nconf_migration_needed
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _nconf_ensure_config_file =="
+_reset_conf
+_expect_true  "conf absent before ensure"          _file_not_exists "${_NIXLPER_USER_CONF}"
+_nconf_ensure_config_file
+_expect_true  "conf created after ensure"          _file_exists    "${_NIXLPER_USER_CONF}"
+_expect_true  "conf not empty"                     _file_contains  "${_NIXLPER_USER_CONF}" "nixlper"
+# Calling again must not overwrite
+echo "custom_marker" >> "${_NIXLPER_USER_CONF}"
+_nconf_ensure_config_file
+_expect_true  "ensure is idempotent"               _file_contains  "${_NIXLPER_USER_CONF}" "custom_marker"
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _nconf_write_setting =="
+_reset_conf
+
+_nconf_write_setting "NIXLPER_EDITOR" "nano" "vim"
+_expect_true  "non-default value written"          _file_contains  "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=nano"
+
+_nconf_write_setting "NIXLPER_EDITOR" "emacs" "vim"
+_expect_true  "value updated in-place"             _file_contains  "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=emacs"
+_expect_eq    "only one EDITOR line"               "$(grep -c 'NIXLPER_EDITOR' "${_NIXLPER_USER_CONF}")" "1"
+
+_nconf_write_setting "NIXLPER_EDITOR" "vim" "vim"
+_expect_false "default value removes override"     _file_contains  "${_NIXLPER_USER_CONF}" "NIXLPER_EDITOR"
+
+_nconf_write_setting "NIXLPER_NAVIGATE_MODE" "flat" "tree"
+_nconf_write_setting "NIXLPER_UPDATE_TIMEOUT" "5" "2"
+_expect_true  "second var written"                 _file_contains  "${_NIXLPER_USER_CONF}" "export NIXLPER_NAVIGATE_MODE=flat"
+_expect_true  "third var written"                  _file_contains  "${_NIXLPER_USER_CONF}" "export NIXLPER_UPDATE_TIMEOUT=5"
+
+# Empty default: always write (no removal)
+_nconf_write_setting "NIXLPER_BOOKMARKS_FILE" "/custom/path" ""
+_expect_true  "empty-default var written"          _file_contains  "${_NIXLPER_USER_CONF}" "export NIXLPER_BOOKMARKS_FILE=/custom/path"
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _nconf_get_meta =="
+_nconf_get_meta "NIXLPER_EDITOR"
+_expect_eq "editor type"            "$_nconf_type"    "text"
+_expect_eq "editor default"         "$_nconf_default" "vim"
+
+_nconf_get_meta "NIXLPER_NAVIGATE_MODE"
+_expect_eq "navigate type"          "$_nconf_type"    "enum:tree:flat"
+_expect_eq "navigate default"       "$_nconf_default" "tree"
+
+_nconf_get_meta "NIXLPER_UPDATE_CHANNEL"
+_expect_eq "channel type"           "$_nconf_type"    "enum:stable:edge:off"
+_expect_eq "channel section"        "$_nconf_section" "common"
+
+_nconf_get_meta "NIXLPER_UPDATE_CHECK_INTERVAL"
+_expect_eq "interval type"          "$_nconf_type"    "int"
+_expect_eq "interval section"       "$_nconf_section" "advanced"
+
+_nconf_get_meta "NIXLPER_DISABLE_WELCOME_MESSAGE"
+_expect_eq "bool type"              "$_nconf_type"    "bool"
+_expect_eq "bool default"           "$_nconf_default" "false"
+
+_expect_false "unknown var returns error"           _nconf_get_meta "NIXLPER_NONEXISTENT"
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _nconf_create_user_conf =="
+_reset_conf
+_nconf_create_user_conf "/opt/nixlper"
+_expect_true  "conf created"                       _file_exists   "${_NIXLPER_USER_CONF}"
+_expect_true  "INSTALL_DIR written"                _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_INSTALL_DIR=/opt/nixlper"
+_expect_true  "editor commented out"               _file_contains "${_NIXLPER_USER_CONF}" "# export NIXLPER_EDITOR=vim"
+# Idempotent — calling again must not overwrite
+echo "my_marker" >> "${_NIXLPER_USER_CONF}"
+_nconf_create_user_conf "/opt/nixlper"
+_expect_true  "create is idempotent"               _file_contains "${_NIXLPER_USER_CONF}" "my_marker"
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo "== _nconf_do_migrate =="
+_reset_conf
+_reset_bashrc
+cat > "${HOME}/.bashrc" << 'BASHRC'
+# user content
+export NIXLPER_INSTALL_DIR=/opt/nixlper
+export NIXLPER_EDITOR=nano
+export NIXLPER_UPDATE_CHANNEL=edge
+source ${NIXLPER_INSTALL_DIR}/nixlper.sh
+# end user content
+BASHRC
+
+export NIXLPER_INSTALL_DIR=/opt/nixlper
+local_backup="${HOME}/.bashrc.nixlper-backup-test"
+_nconf_do_migrate "$local_backup"
+
+_expect_true  "backup created"                     _file_exists   "$local_backup"
+_expect_true  "conf created"                       _file_exists   "${_NIXLPER_USER_CONF}"
+_expect_true  "INSTALL_DIR in conf"                _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_INSTALL_DIR=/opt/nixlper"
+_expect_true  "EDITOR in conf"                     _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_EDITOR=nano"
+_expect_true  "CHANNEL in conf"                    _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_UPDATE_CHANNEL=edge"
+_expect_false "NIXLPER_ vars gone from bashrc"     _file_contains "${HOME}/.bashrc" "^export NIXLPER_"
+_expect_true  "user content preserved"             _file_contains "${HOME}/.bashrc" "# user content"
+_expect_true  "source line hardened"               _file_contains "${HOME}/.bashrc" "source /opt/nixlper/nixlper.sh"
+_expect_false "variable source line removed"       _file_contains "${HOME}/.bashrc" 'source ${NIXLPER_INSTALL_DIR}'
+
+#-----------------------------------------------------------------------------------------------------------------------
+echo ""
+echo "====================================================================================================="
+echo "RESULT: ${PASS} passed, ${FAIL} failed"
+echo "====================================================================================================="
+[[ ${FAIL} -eq 0 ]]

--- a/src/test/bash/test_functions_config.sh
+++ b/src/test/bash/test_functions_config.sh
@@ -217,6 +217,22 @@ _expect_false "bashrc value (nano) does not overwrite conf-file"  \
 _expect_true  "bashrc-only var (CHANNEL) still imported"          \
               _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_UPDATE_CHANNEL=edge"
 
+# Bug 4 regression: syntax check must run on tmp file BEFORE mv, so original config is never
+# destroyed on error. Use a var NOT in the config file so the broken .bashrc line reaches bash -n.
+_reset_bashrc
+# NIXLPER_UPDATE_CHANNEL in config (safe), NIXLPER_EDITOR only in .bashrc (broken)
+mkdir -p "${HOME}/.config/nixlper"
+printf "export NIXLPER_UPDATE_CHANNEL=stable\n" > "${_NIXLPER_USER_CONF}"
+printf "export NIXLPER_EDITOR='unclosed_quote\n" >> "${HOME}/.bashrc"
+
+local_backup3="${HOME}/.bashrc.nixlper-backup-test3"
+_nconf_do_migrate "$local_backup3" 2>/dev/null || true  # expected to fail
+
+_expect_true  "original config intact after syntax-error migration" \
+              _file_contains "${_NIXLPER_USER_CONF}" "export NIXLPER_UPDATE_CHANNEL=stable"
+_expect_false "broken value not written to config" \
+              _file_contains "${_NIXLPER_USER_CONF}" "unclosed_quote"
+
 #-----------------------------------------------------------------------------------------------------------------------
 echo ""
 echo "====================================================================================================="


### PR DESCRIPTION
Introduces functions_config.sh with nconf (CTRL+X+C) — an fzf-powered
interactive editor for ~/.config/nixlper/nixlper.conf. Common settings
use type-appropriate pickers (bool toggle, enum list, text/int prompt);
only non-default values are written. The updated installer writes a
minimal ~/.bashrc (source line only) and creates a documented config
file template. First-run migration is offered when old-style
export NIXLPER_* lines are detected in ~/.bashrc: backs up, writes
config file, hardens the source line, and strips the variables — with
full recovery instructions printed on failure.

https://claude.ai/code/session_01UeEdjyb3y9sdkewNkT44ed