### PR TITLE
🐛fix|Fix edge channel in version release mechanism.

### DIFF
--- a/.github/workflows/publish_edge_on_push.yml
+++ b/.github/workflows/publish_edge_on_push.yml
@@ -18,6 +18,11 @@ concurrency:
 
 jobs:
   publish-edge:
+    # Skip on release commits — the stable release workflow handles those.
+    # Running on a release commit risks inheriting the vX.Y.Z tag (race with
+    # create_release_on_tag.yml) and would publish an edge build identical to
+    # the stable release, confusing the edge update check.
+    if: "!startsWith(github.event.head_commit.message, '🔖release|')"
     runs-on: ubuntu-latest
     steps:
       - name: Install dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -495,13 +495,15 @@ to `$NIXLPER_INSTALL_DIR/snapshots` and `$NIXLPER_INSTALL_DIR/custom` when not e
 
 Two channels selected via `NIXLPER_UPDATE_CHANNEL`: `stable` (compares installed `VERSION:`
 against GitHub `releases/latest`), `edge` (compares installed full `COMMIT:` SHA against the
-latest commit on `main`), and `off`. All network access is gated by `_i_is_online` — a
-time-boxed `curl` reachability probe — so an offline machine never hangs or errors at login.
-Automatic startup checks are throttled via `NIXLPER_UPDATE_CACHE_FILE`; the `nu` / `CTRL+X+W`
-command bypasses the throttle and always reports. The `edge` channel relies on `build.sh`
-writing the full SHA (`COMMIT:`) into the `version` file, and on CI's rolling `edge`
-pre-release (`.github/workflows/publish_edge_on_push.yml`), which is excluded from
-`create_release_on_tag.yml` via a `!edge` tag filter. `install.sh` accepts `--channel
+`target_commitish` of the rolling `edge` pre-release — **not** raw `main` HEAD), and `off`.
+All network access is gated by `_i_is_online` — a time-boxed `curl` reachability probe — so
+an offline machine never hangs or errors at login. Automatic startup checks are throttled via
+`NIXLPER_UPDATE_CACHE_FILE`; the `nu` / `CTRL+X+W` command bypasses the throttle and always
+reports. The `edge` channel relies on `build.sh` writing the full SHA (`COMMIT:`) into the
+`version` file, and on CI's rolling `edge` pre-release
+(`.github/workflows/publish_edge_on_push.yml`), which skips release commits (prevents a race
+where `vX.Y.Z` is embedded in the edge artifact and a false-positive update loop) and is
+excluded from `create_release_on_tag.yml` via a `!edge` tag filter. `install.sh` accepts `--channel
 stable|edge` and `--yes`, and aborts cleanly when the internet is unreachable.
 
 Automated tests live in `src/test/bash/test_functions_update.sh` (pure bash, no framework,

--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -186,7 +186,7 @@ same machine via `/tmp`. `tc` and `tp` both `chmod 644` the files they place the
 | Channel | Compares |
 |---|---|
 | `stable` | Installed `VERSION:` field vs. GitHub `releases/latest` tag |
-| `edge` | Installed `COMMIT:` SHA vs. latest commit SHA on `main` |
+| `edge` | Installed `COMMIT:` SHA vs. `target_commitish` of the `edge` pre-release |
 | `off` | No network check at startup |
 
 `build.sh` writes both fields into the `version` file at build time.
@@ -205,5 +205,23 @@ offline, the check is skipped silently — no error, no hang at login.
 ### Edge pre-release
 
 CI publishes a rolling `edge` pre-release via `.github/workflows/publish_edge_on_push.yml` on
-every push to `main`. The release creation workflow (`create_release_on_tag.yml`) excludes it
-via a `!edge` tag filter so it is never promoted to a stable release.
+every push to `main` **except release commits** (messages starting with `🔖release|` are
+skipped). Skipping release commits prevents two problems: (1) a race where the `vX.Y.Z` tag
+created by `create_release_on_tag.yml` is visible to the edge build's `git describe` call,
+causing the edge artifact to embed `VERSION: vX.Y.Z` and become indistinguishable from the
+stable release; (2) the edge release pointing to the same commit as stable, which makes
+the edge update check loop (see below).
+
+The release creation workflow (`create_release_on_tag.yml`) excludes the `edge` tag via a
+`!edge` tag filter so it is never promoted to a stable release.
+
+### Why the edge update check uses the pre-release SHA, not `main` HEAD
+
+`_i_remote_edge_release_commit` fetches `target_commitish` from the `edge` GitHub pre-release
+(the full SHA passed to `--target` when CI published the build) instead of the raw HEAD of
+`main`. This prevents a false-positive loop: if the edge workflow is skipped on a release
+commit, the latest commit on `main` is the release SHA but the edge pre-release is still at
+the prior commit. Comparing against `main` HEAD would always show "update available" even
+after updating, because the user installs the pre-release SHA (old) which still differs from
+the main HEAD (release). Comparing against the pre-release SHA gives the correct answer:
+"up to date" when the user has what CI actually published.

--- a/src/main/bash/functions_update.sh
+++ b/src/main/bash/functions_update.sh
@@ -47,12 +47,14 @@ function _i_remote_latest_tag() {
     | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/'
 }
 
-# Latest commit SHA on the default branch, empty on failure.
-function _i_remote_latest_commit() {
+# Commit SHA that the rolling edge pre-release was built from (its target_commitish),
+# empty on failure. Using the release SHA — not the raw HEAD of main — means
+# "update available" is only shown when a new build is actually downloadable.
+function _i_remote_edge_release_commit() {
   curl -fsSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
-    "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/commits/main" 2>/dev/null \
-    | grep -m1 '"sha"' \
-    | sed -E 's/.*"sha":[[:space:]]*"([^"]+)".*/\1/'
+    "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/releases/tags/edge" 2>/dev/null \
+    | grep -m1 '"target_commitish"' \
+    | sed -E 's/.*"target_commitish":[[:space:]]*"([^"]+)".*/\1/'
 }
 
 # Return 0 if $1 is a strictly greater version than $2 (version sort), avoiding false
@@ -198,7 +200,7 @@ function _i_check_edge() {
   local -r force="${1:-false}"
   local installed latest
   installed=$(_i_installed_version_field "COMMIT:")
-  latest=$(_i_remote_latest_commit)
+  latest=$(_i_remote_edge_release_commit)
 
   if [[ -z "${latest}" ]]; then
     [[ "${force}" == "true" ]] && echo "⚠️  Could not determine the latest commit."

--- a/src/test/bash/test_functions_update.sh
+++ b/src/test/bash/test_functions_update.sh
@@ -76,7 +76,7 @@ _reset_throttle() { rm -f "${NIXLPER_UPDATE_CACHE_FILE}"; }
 # Default mocks — individual tests override as needed.
 _i_is_online() { return 0; }
 _i_remote_latest_tag() { echo ""; }
-_i_remote_latest_commit() { echo ""; }
+_i_remote_edge_release_commit() { echo ""; }
 
 #-----------------------------------------------------------------------------------------------------------------------
 echo "== _i_version_gt =="
@@ -145,11 +145,11 @@ _expect_eq "newer-than-remote: no downgrade noise" "${out}" ""
 echo "== edge channel =="
 export NIXLPER_UPDATE_CHANNEL=edge
 _write_version "" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-_i_remote_latest_commit() { echo "1111111111111111111111111111111111111111"; }
+_i_remote_edge_release_commit() { echo "1111111111111111111111111111111111111111"; }
 _reset_throttle
 out="$(_i_check_for_updates true 2>&1)"
 _expect_match_count "new commit notifies" "${out}" "newer Nixlper commit" 1
-_i_remote_latest_commit() { echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; }
+_i_remote_edge_release_commit() { echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"; }
 _reset_throttle
 out="$(_i_check_for_updates true 2>&1)"
 _expect_match_count "same commit: up to date" "${out}" "latest commit" 1


### PR DESCRIPTION
Two bugs: (1) publish_edge_on_push.yml fired on release commits,
risking a race where the vX.Y.Z tag was already present at edge
build time (via create_release_on_tag.yml running concurrently),
embedding VERSION: vX.Y.Z in the edge artifact. Fixed by skipping
the job when the commit message starts with 🔖release|.

(2) _i_remote_latest_commit() compared the installed COMMIT SHA
against the raw HEAD of main instead of the edge pre-release SHA.
After fix (1), a release commit advances main HEAD but the edge
release stays at the prior commit, so every update check showed
"update available" even after updating. Fixed by renaming the
function to _i_remote_edge_release_commit() and fetching
target_commitish from /releases/tags/edge so the check only fires
when a new build is actually downloadable.

https://claude.ai/code/session_013VxHKU89qjcLyt328qcD4L