### PR TITLE
📝docs|Populate [Unreleased] CHANGELOG with post-v2.2.0 fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`INTERNALS.md`**: documents the mechanism behind non-obvious features — macro
+  `PROMPT_COMMAND` recording, navigation alias namespace/cleanup, command palette
+  `bind -x` dispatch, target staging lifecycle, and update detection
+  channels/throttling.
+
+### Fixed
+- **DEB version on release builds**: `build-deb.sh` now detects an exact git tag and
+  strips the leading `v` (matching RPM behaviour); untagged builds fall back to
+  `0~<sha>`. Release DEBs now carry a meaningful version number.
+- **Edge channel false update loop**: the update check now fetches the SHA from
+  `/releases/tags/edge` (via `_i_remote_edge_release_commit()`) instead of raw
+  `main` HEAD, so a release commit that advances `main` without publishing a new
+  edge artifact no longer triggers a spurious "update available" prompt.
+- **Edge CI race on release commits**: `publish_edge_on_push.yml` now skips when the
+  commit message starts with `🔖release|`, preventing a race where the release tag
+  was already present at edge-build time and the wrong version got embedded in the
+  edge artifact.
+- **Stale navigation aliases**: `functions_navigation.sh` now tracks the previous
+  alias count and unaliases stale `v*/n*/d*/tc*/tm*/cdf*` shortcuts before
+  regenerating them, so switching to a smaller directory no longer leaves phantom
+  shortcuts from the previous (larger) listing.
+- **Macro recording reliability**: macro recording no longer scrapes `~/.bash_history`;
+  it now uses a `PROMPT_COMMAND` hook that appends each command into an in-memory
+  array. `sr`/`fr` invocations are excluded automatically.
+
+### Changed
+- **`_i_get_pid_by_port()`**: tries `ss` first, falls back to `netstat`, and errors
+  cleanly when neither is installed.
+
 ---
 
 ## [2.2.0] - 2026-06-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ commit that fixes the underlying bug.
 2. **`README.md` → `## Features`** — public reference. Must stay in sync with the help files (see "Dual-location documentation rule"). Update in the same commit as the code.
 3. **`CLAUDE.md`** — update if the session introduces new files, directories, env variables, architectural decisions, or constraints.
 4. **`KNOWN_ISSUES.md`** — remove an entry in the same commit that fixes the underlying bug. Add an entry for newly discovered confirmed-but-unfixed defects.
-5. **`CHANGELOG.md`** — when cutting a release, populate from `git log` since the last tag (see "Release process").
+5. **`CHANGELOG.md`** — after every bug fix or feature, add a bullet to the `[Unreleased]` section under the appropriate heading (`Added`, `Fixed`, `Changed`, or `Removed`). When cutting a release, promote the `[Unreleased]` entries into a versioned block and clear the section (see "Release process").
 6. **Palette rendering** — if any `@cmd-palette` command was added or modified, verify it renders correctly (see "Command palette rendering check" under Testing requirement). A command with no `@keybind` or `@alias` may have a blank keybind column — that is acceptable. What is **never acceptable** is a command that *has* a keybind or alias defined but it does not appear in the palette column.
 7. **`INTERNALS.md`** — update if a feature's mechanism changes in a non-obvious way (see "INTERNALS.md rule" below).
 


### PR DESCRIPTION
Documents three post-release commits that were missing from [Unreleased]:
DEB version fix (#91), PROMPT_COMMAND macro refactor + stale alias fix
+ ss/netstat abstraction (#92), and edge channel race/false-update fix (#93).

https://claude.ai/code/session_01726fgFkG6ktJFHbxVULuvQ