### PR TITLE
Fix update check always reporting offline in restricted environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DEB version on release builds**: `build-deb.sh` now detects an exact git tag and
   strips the leading `v` (matching RPM behaviour); untagged builds fall back to
   `0~<sha>`. Release DEBs now carry a meaningful version number.
+- **Update check always reporting offline**: `_i_is_online` was probing
+  `https://api.github.com` which returns HTTP 403 in unauthenticated cloud/CI
+  environments; curl's `-f` flag treats 4xx as failure, so nixlper always skipped
+  the update check. Probe changed to `https://github.com` (reliably returns 200).
+  Also removed `-f` from the three API endpoint helpers — those return valid JSON
+  on individual endpoints even when the root is 403, and `-f` was silently discarding
+  successful API responses.
 - **Edge channel false update loop**: the update check now fetches the SHA from
   `/releases/tags/edge` (via `_i_remote_edge_release_commit()`) instead of raw
   `main` HEAD, so a release commit that advances `main` without publishing a new

--- a/src/main/bash/functions_update.sh
+++ b/src/main/bash/functions_update.sh
@@ -26,9 +26,11 @@ function _i_update_cache_file() {
 }
 
 # Return 0 if GitHub is reachable within NIXLPER_UPDATE_TIMEOUT seconds, 1 otherwise.
+# Probes github.com (not api.github.com — that returns 403 in some environments, which
+# curl -f treats as a failure even though the network is up).
 function _i_is_online() {
   command -v curl >/dev/null 2>&1 || return 1
-  curl -fsS --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" -o /dev/null "https://api.github.com" 2>/dev/null
+  curl -fsS --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" -o /dev/null "https://github.com" 2>/dev/null
 }
 
 # Echo a field from the installed version file (e.g. "VERSION:" or "COMMIT:"), empty if absent.
@@ -40,8 +42,10 @@ function _i_installed_version_field() {
 }
 
 # Latest published (non-prerelease) release tag, empty on failure.
+# Note: -f is intentionally omitted — api.github.com returns 403 on unauthenticated
+# root requests in some environments, but individual endpoint responses are 200 and valid.
 function _i_remote_latest_tag() {
-  curl -fsSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
+  curl -sSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
     "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/releases/latest" 2>/dev/null \
     | grep '"tag_name"' \
     | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/'
@@ -51,7 +55,7 @@ function _i_remote_latest_tag() {
 # empty on failure. Using the release SHA — not the raw HEAD of main — means
 # "update available" is only shown when a new build is actually downloadable.
 function _i_remote_edge_release_commit() {
-  curl -fsSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
+  curl -sSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
     "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/releases/tags/edge" 2>/dev/null \
     | grep -m1 '"target_commitish"' \
     | sed -E 's/.*"target_commitish":[[:space:]]*"([^"]+)".*/\1/'
@@ -268,7 +272,7 @@ function _check_update() {
 
 # Fetch the body text of the edge pre-release from GitHub API, empty on failure.
 function _i_fetch_edge_release_body() {
-  curl -fsSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
+  curl -sSL --max-time "${NIXLPER_UPDATE_TIMEOUT:-2}" \
     "https://api.github.com/repos/${NIXLPER_GITHUB_REPO}/releases/tags/edge" 2>/dev/null \
     | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('body',''))" 2>/dev/null
 }


### PR DESCRIPTION
## Summary
The update check was always reporting the system as offline in unauthenticated cloud/CI environments, causing the update checker to silently skip. This was caused by probing `api.github.com` (which returns HTTP 403 in restricted environments) and using curl's `-f` flag (which treats 4xx responses as failures).

## Changes
- **`_i_is_online()` connectivity probe**: Changed from `https://api.github.com` to `https://github.com`, which reliably returns HTTP 200 in all environments. The API endpoint returns 403 in unauthenticated contexts, but the main domain is always reachable.
- **API endpoint helpers**: Removed the `-f` flag from `_i_remote_latest_tag()`, `_i_remote_edge_release_commit()`, and `_i_fetch_edge_release_body()`. These endpoints return valid JSON responses with HTTP 200 even when the root API returns 403; the `-f` flag was silently discarding successful responses.
- **Documentation**: Added clarifying comments explaining why `api.github.com` is problematic and why `-f` was removed from the API calls.

## Implementation Details
- The connectivity check now probes the main GitHub domain instead of the API root, avoiding 403 responses in restricted environments.
- API endpoint calls now rely on the actual HTTP response body (valid JSON) rather than the status code, making them resilient to authentication-related 403 responses at the API root level.
- All changes are backward compatible; no behavior changes for users in standard environments.

https://claude.ai/code/session_01DrkZ4zEfB3fa4Bx9XJfun8